### PR TITLE
failing integration test shows file path as error message

### DIFF
--- a/org.elysium.test/src/org/elysium/test/integration/Integration.java
+++ b/org.elysium.test/src/org/elysium/test/integration/Integration.java
@@ -83,7 +83,7 @@ public class Integration extends LilyPondTestWithValidator {
 				}
 			}
 		}
-		assertFalse(hasErrors);
+		assertFalse(filePath, hasErrors);
 	}
 
 }


### PR DESCRIPTION
If an integration test fails, it would be nice to see the errors not only in the console. With this simple modification the problematic file appears as error message on the failing test in the JUnit-View.

In the first place, this pull request is a test run (for me) for potential further contributions.