### PR TITLE
#48 add cancel button to compile view

### DIFF
--- a/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
+++ b/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
@@ -33,7 +33,6 @@ import org.eclipse.ui.console.IConsoleConstants;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.progress.IProgressConstants;
-import org.eclipse.util.ConsoleUtils;
 import org.eclipse.util.EditorUtils;
 import org.eclipse.util.UiUtils;
 import org.elysium.ui.Activator;
@@ -70,9 +69,9 @@ public class CompilerJob extends Job {
 		monitor.beginTask("LilyPond Compilation", 4);
 		try {
 			checkCancelled(monitor);
+			console.setMonitor(monitor);
 			console.clearConsole();
 			console.firePropertyChange(this, IConsoleConstants.P_CONSOLE_OUTPUT_COMPLETE, null, false);
-			ConsoleUtils.showConsole(console);
 
 			long start = System.currentTimeMillis();
 			preprocess(monitor);
@@ -112,6 +111,7 @@ public class CompilerJob extends Job {
 			Activator.logError("Workspace build interrupted", e);
 			returnStatus=Status.CANCEL_STATUS;
 		}
+		console.setMonitor(null);
 		return returnStatus;
 	}
 


### PR DESCRIPTION
I added a button for cancelling a compilation job, and for closing the compiler console for a particular file.
If the console is not pinned, the console for a particular file is activated if its content changes (otherwise a finished job may remain in the foreground even if other builds are still running).