### PR TITLE
fix NPE in CompilerConsole

### DIFF
--- a/org.elysium.ui/src/org/elysium/ui/compiler/CompilerConsole.java
+++ b/org.elysium.ui/src/org/elysium/ui/compiler/CompilerConsole.java
@@ -68,7 +68,7 @@ public class CompilerConsole extends MessageConsole {
 	}
 
 	private void print(MessageConsoleStream stream, String line){
-		if(!view.isPinned()){
+		if(view==null || !view.isPinned()){
 			ConsoleUtils.showConsole(this);
 		}
 		if(!viewDiscarded){


### PR DESCRIPTION
Unfortunately, I introduced an NPE with a previous fix. It hits e.g. on Eclipse startup or if the console was not active and hence the CompilerConsole is not initialized yet.