### PR TITLE
#72 allow moving source along with compiled score

### DIFF
--- a/org.elysium.ui/src/org/elysium/ui/refactoring/MoveFileParticipant.java
+++ b/org.elysium.ui/src/org/elysium/ui/refactoring/MoveFileParticipant.java
@@ -1,5 +1,8 @@
 package org.elysium.ui.refactoring;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResourceDelta;
@@ -23,6 +26,7 @@ import org.elysium.ui.Activator;
 public class MoveFileParticipant extends MoveParticipant {
 
 	private IFile sourceFile;
+	private List<IFile> compiledFilesIncludedInMove=new ArrayList<IFile>();
 
 	@Override
 	protected boolean initialize(Object element) {
@@ -53,6 +57,9 @@ public class MoveFileParticipant extends MoveParticipant {
 								if (RefactoringSupport.isSource(file)) {
 									result.addFatalError("Moving multiple LilyPond source files is not supported");
 								}
+								if(RefactoringSupport.isCompiledFrom(file, sourceFile)){
+									compiledFilesIncludedInMove.add(file);
+								}
 							}
 						}
 						return true;
@@ -68,7 +75,7 @@ public class MoveFileParticipant extends MoveParticipant {
 	@Override
 	public Change createChange(IProgressMonitor pm) throws CoreException, OperationCanceledException {
 		IContainer destination = (IContainer)getArguments().getDestination();
-		return RefactoringSupport.createChange(sourceFile, sourceFile.getName(), destination, false);
+		return RefactoringSupport.createChange(sourceFile, sourceFile.getName(), destination, false, compiledFilesIncludedInMove);
 	}
 
 	@Override

--- a/org.elysium.ui/src/org/elysium/ui/refactoring/RenameFileParticipant.java
+++ b/org.elysium.ui/src/org/elysium/ui/refactoring/RenameFileParticipant.java
@@ -1,5 +1,7 @@
 package org.elysium.ui.refactoring;
 
+import java.util.Collections;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -35,7 +37,7 @@ public class RenameFileParticipant extends RenameParticipant {
 	@Override
 	public Change createChange(IProgressMonitor pm) throws CoreException, OperationCanceledException {
 		String newName = getArguments().getNewName();
-		return RefactoringSupport.createChange(sourceFile, newName, sourceFile.getParent(), false);
+		return RefactoringSupport.createChange(sourceFile, newName, sourceFile.getParent(), false, Collections.<IFile>emptyList());
 	}
 
 }


### PR DESCRIPTION
There are a number of stumble stones connected with the refactoring.
* a MoveResourceChange must be created only if the corresponding file is not part of the refactoring anyway (user selection of multiple files for moving)
* a MoveResourceChange/DeleteResourceChange does not trigger a new refactoring - i.e. another RefactoringParticipant responsible for that change will not be notified (hence the dirty hack in ensureScoreCanBeRefactored making sure that the Score View's delete participant unregisters the score; I have not found cleaner solution)

Moving the pdf alone does not work, yet. For that a MoveParticipant in the pdf view plugin would be the way to go.