### PR TITLE
add XtextTools and more possible target platforms to Oomph setup

### DIFF
--- a/Elysium.setup
+++ b/Elysium.setup
@@ -15,7 +15,7 @@
     label="Elysium">
   <setupTask
       xsi:type="setup:VariableTask"
-      type="RESOURCE"
+      type="FILE"
       name="lilypondlocation"
       defaultValue=""
       label="LilyPond executable location">
@@ -25,6 +25,18 @@
     </description>
   </setupTask>
   <setupTask
+      xsi:type="setup:VariableTask"
+      name="xtext.release.composite"
+      value="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
+  <setupTask
+      xsi:type="setup:VariableTask"
+      name="xtexttools.update.site"
+      value="http://xtexttools.libutzki.de/"/>
+  <setupTask
+      xsi:type="setup:VariableTask"
+      name="antlr-gen.update.site"
+      value="http://download.itemis.com/updates/releases/2.1.1/"/>
+  <setupTask
       xsi:type="setup.p2:P2Task"
       id="Xtext stuff"
       label="Xtext stuff">
@@ -33,10 +45,18 @@
         versionRange="[2.7.0,2.8.0)"/>
     <requirement
         name="de.itemis.xtext.antlr.sdk.feature.group"/>
+    <requirement
+        name="de.libutzki.xtext.nodemodeloutline.feature.feature.group"
+        optional="true"/>
+    <requirement
+        name="de.libutzki.xtext.semanticmodeloutline.feature.feature.group"
+        optional="true"/>
     <repository
-        url="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
+        url="${xtext.release.composite}"/>
     <repository
-        url="http://download.itemis.com/updates/releases/2.1.1"/>
+        url="${antlr-gen.update.site}"/>
+    <repository
+        url="${xtexttools.update.site}"/>
   </setupTask>
   <setupTask
       xsi:type="git:GitCloneTask"
@@ -91,16 +111,55 @@
           versionRange="[2.7.0,2.8.0)"/>
       <requirement
           name="org.eclipse.platform.feature.group"/>
+      <requirement
+          name="de.libutzki.xtext.nodemodeloutline.feature.feature.group"
+          optional="true"/>
+      <requirement
+          name="de.libutzki.xtext.semanticmodeloutline.feature.feature.group"
+          optional="true"/>
+      <repositoryList
+          name="Mars">
+        <repository
+            url="http://download.eclipse.org/releases/mars/"/>
+        <repository
+            url="${xtext.release.composite}"/>
+        <repository
+            url="${antlr-gen.update.site}"/>
+        <repository
+            url="${xtexttools.update.site}"/>
+      </repositoryList>
       <repositoryList
           name="Luna">
         <repository
-            url="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
-        <repository
-            url="http://download.itemis.com/updates/releases/2.1.0/"/>
-        <repository
-            url="http://download.eclipse.org/technology/m2e/releases/1.0/"/>
-        <repository
             url="http://download.eclipse.org/releases/luna/"/>
+        <repository
+            url="${xtext.release.composite}"/>
+        <repository
+            url="${antlr-gen.update.site}"/>
+        <repository
+            url="${xtexttools.update.site}"/>
+      </repositoryList>
+      <repositoryList
+          name="Kepler">
+        <repository
+            url="http://download.eclipse.org/releases/kepler/"/>
+        <repository
+            url="${xtext.release.composite}"/>
+        <repository
+            url="${antlr-gen.update.site}"/>
+        <repository
+            url="${xtexttools.update.site}"/>
+      </repositoryList>
+      <repositoryList
+          name="Juno">
+        <repository
+            url="http://download.eclipse.org/releases/juno/"/>
+        <repository
+            url="${xtext.release.composite}"/>
+        <repository
+            url="${antlr-gen.update.site}"/>
+        <repository
+            url="${xtexttools.update.site}"/>
       </repositoryList>
     </targlet>
   </setupTask>
@@ -116,7 +175,7 @@
   <setupTask
       xsi:type="setup:ResourceCreationTask"
       excludedTriggers="BOOTSTRAP"
-      successor="//@setupTasks.4"
+      successor="//@setupTasks.7"
       content="&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; standalone=&quot;no&quot;?>&#xD;&#xA;&lt;launchConfiguration type=&quot;org.eclipse.jdt.junit.launchconfig&quot;>&#xD;&#xA;&lt;listAttribute key=&quot;org.eclipse.debug.core.MAPPED_RESOURCE_PATHS&quot;>&#xD;&#xA;&lt;listEntry value=&quot;/org.elysium.test&quot;/>&#xD;&#xA;&lt;/listAttribute>&#xD;&#xA;&lt;listAttribute key=&quot;org.eclipse.debug.core.MAPPED_RESOURCE_TYPES&quot;>&#xD;&#xA;&lt;listEntry value=&quot;4&quot;/>&#xD;&#xA;&lt;/listAttribute>&#xD;&#xA;&lt;stringAttribute key=&quot;org.eclipse.jdt.junit.CONTAINER&quot; value=&quot;=org.elysium.test&quot;/>&#xD;&#xA;&lt;booleanAttribute key=&quot;org.eclipse.jdt.junit.KEEPRUNNING_ATTR&quot; value=&quot;false&quot;/>&#xD;&#xA;&lt;stringAttribute key=&quot;org.eclipse.jdt.junit.TESTNAME&quot; value=&quot;&quot;/>&#xD;&#xA;&lt;stringAttribute key=&quot;org.eclipse.jdt.junit.TEST_KIND&quot; value=&quot;org.eclipse.jdt.junit.loader.junit4&quot;/>&#xD;&#xA;&lt;stringAttribute key=&quot;org.eclipse.jdt.launching.MAIN_TYPE&quot; value=&quot;&quot;/>&#xD;&#xA;&lt;stringAttribute key=&quot;org.eclipse.jdt.launching.PROJECT_ATTR&quot; value=&quot;org.elysium.test&quot;/>&#xD;&#xA;&lt;stringAttribute key=&quot;org.eclipse.jdt.launching.VM_ARGUMENTS&quot; value=&quot;-Dlilypond.path=${lilypondlocation}&quot;/>&#xD;&#xA;&lt;/launchConfiguration>"
       targetURL="${git.clone.elysium.location|uri}/org.elysium.test/.launch/Elysium Tests.launch"
       encoding="UTF-8"/>


### PR DESCRIPTION
I did not rewrite the entire setup, as the compare view indicates.
I extracted update site urls to variables, added XtextTools and added Juno, Kepler and Mars as additional possible target platforms - changes proposed in #74