### PR TITLE
restrict number of parallel running LilyPond instances

### DIFF
--- a/org.elysium.ui/src/org/elysium/ui/compiler/NumberedQueueSchedulingRule.java
+++ b/org.elysium.ui/src/org/elysium/ui/compiler/NumberedQueueSchedulingRule.java
@@ -1,0 +1,29 @@
+package org.elysium.ui.compiler;
+
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+
+/**
+ * Rule allows only one job for each queue number at a time.
+ * This allows to restrict the number of parallel executions to be limited 
+ * by creating an according number of queue rules.
+ */
+public class NumberedQueueSchedulingRule implements ISchedulingRule {
+		private long queuenumer;
+
+	public NumberedQueueSchedulingRule(long queuenumer) {
+		this.queuenumer = queuenumer;
+	}
+
+	public boolean contains(ISchedulingRule rule) {
+		return rule == this;
+	}
+
+	public boolean isConflicting(ISchedulingRule rule) {
+		if (rule instanceof NumberedQueueSchedulingRule) {
+			NumberedQueueSchedulingRule otherRule = (NumberedQueueSchedulingRule) rule;
+			return otherRule.queuenumer == queuenumer;
+		}
+		return false;
+	}
+
+}

--- a/org.elysium.ui/src/org/elysium/ui/compiler/preferences/CompilerPreferenceConstants.java
+++ b/org.elysium.ui/src/org/elysium/ui/compiler/preferences/CompilerPreferenceConstants.java
@@ -6,5 +6,6 @@ public enum CompilerPreferenceConstants {
 	POINT_AND_CLICK,
 	VERBOSE,
 	COMMAND_LINE,
-	SEARCH_PATHS
+	SEARCH_PATHS,
+	PARALLEL_COMPILES;
 }

--- a/org.elysium.ui/src/org/elysium/ui/compiler/preferences/CompilerPreferenceInitializer.java
+++ b/org.elysium.ui/src/org/elysium/ui/compiler/preferences/CompilerPreferenceInitializer.java
@@ -26,6 +26,8 @@ public class CompilerPreferenceInitializer extends AbstractPreferenceInitializer
 		preferenceStore.setDefault(CompilerPreferenceConstants.VERBOSE.name(), false);
 
 		preferenceStore.setDefault(CompilerPreferenceConstants.SEARCH_PATHS.name(), ""); //$NON-NLS-1$
+
+		preferenceStore.setDefault(CompilerPreferenceConstants.PARALLEL_COMPILES.name(), 5);
 	}
 
 }

--- a/org.elysium.ui/src/org/elysium/ui/compiler/preferences/CompilerPreferencePage.java
+++ b/org.elysium.ui/src/org/elysium/ui/compiler/preferences/CompilerPreferencePage.java
@@ -16,7 +16,9 @@ public class CompilerPreferencePage extends AbstractLilyPondPreferencePage {
 		addField(new BooleanFieldEditor(CompilerPreferenceConstants.POINT_AND_CLICK.name(), "Point and click", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(CompilerPreferenceConstants.VERBOSE.name(), "Verbose output", getFieldEditorParent()));
 		addField(new PathEditor(CompilerPreferenceConstants.SEARCH_PATHS.name(), "Search folders", "Browse for a search folder", getFieldEditorParent()));
-		addField(new IntegerFieldEditor(CompilerPreferenceConstants.PARALLEL_COMPILES.name(), "Parallel LilyPond calls", getFieldEditorParent(),2));
+		IntegerFieldEditor parallelCompilesEditor = new IntegerFieldEditor(CompilerPreferenceConstants.PARALLEL_COMPILES.name(), "Parallel LilyPond calls", getFieldEditorParent());
+		parallelCompilesEditor.setValidRange(1, 50);
+		addField(parallelCompilesEditor);
 		addField(new MultilineStringFieldEditor(CompilerPreferenceConstants.COMMAND_LINE.name(), "Additional command line options\n(separated by newline)", getFieldEditorParent()));
 	}
 

--- a/org.elysium.ui/src/org/elysium/ui/compiler/preferences/CompilerPreferencePage.java
+++ b/org.elysium.ui/src/org/elysium/ui/compiler/preferences/CompilerPreferencePage.java
@@ -2,6 +2,7 @@ package org.elysium.ui.compiler.preferences;
 
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FileFieldEditor;
+import org.eclipse.jface.preference.IntegerFieldEditor;
 import org.eclipse.jface.preference.PathEditor;
 import org.eclipse.util.MultilineStringFieldEditor;
 import org.elysium.ui.preferences.AbstractLilyPondPreferencePage;
@@ -15,6 +16,7 @@ public class CompilerPreferencePage extends AbstractLilyPondPreferencePage {
 		addField(new BooleanFieldEditor(CompilerPreferenceConstants.POINT_AND_CLICK.name(), "Point and click", getFieldEditorParent()));
 		addField(new BooleanFieldEditor(CompilerPreferenceConstants.VERBOSE.name(), "Verbose output", getFieldEditorParent()));
 		addField(new PathEditor(CompilerPreferenceConstants.SEARCH_PATHS.name(), "Search folders", "Browse for a search folder", getFieldEditorParent()));
+		addField(new IntegerFieldEditor(CompilerPreferenceConstants.PARALLEL_COMPILES.name(), "Parallel LilyPond calls", getFieldEditorParent(),2));
 		addField(new MultilineStringFieldEditor(CompilerPreferenceConstants.COMMAND_LINE.name(), "Additional command line options\n(separated by newline)", getFieldEditorParent()));
 	}
 


### PR DESCRIPTION
On my machine a clean build of a project with many files freezes the system because many LilyPond instances are running simultaneously. I propose that the user can configure the number of parallel executions (on the already existing compiler preference page).

The implementation makes use of scheduling rules preventing multiple jobs with the same rule running at the same time.