### PR TITLE
more passing integration tests

### DIFF
--- a/org.elysium.test/src/org/elysium/test/integration/Integration.java
+++ b/org.elysium.test/src/org/elysium/test/integration/Integration.java
@@ -70,7 +70,7 @@ public class Integration extends LilyPondTestWithValidator {
 	}
 
 	private static final String[] DIRECTORY_NAMES = {
-//		"failingIntegrationTests"
+		"failingIntegrationTests",
 		"init",
 		"snippets"
 	};

--- a/org.elysium.test/src/org/elysium/test/integration/Integration.java
+++ b/org.elysium.test/src/org/elysium/test/integration/Integration.java
@@ -70,6 +70,7 @@ public class Integration extends LilyPondTestWithValidator {
 	}
 
 	private static final String[] DIRECTORY_NAMES = {
+//		"failingIntegrationTests"
 		"init",
 		"snippets"
 	};
@@ -116,8 +117,11 @@ public class Integration extends LilyPondTestWithValidator {
 	}
 
 	private void copyCurrentFileToFailingTestsFolder() throws Exception{
-		File currentFile = new File(filePath);
-		Files.copy(currentFile, new File("failingIntegrationTests", currentFile.getName()));
+		File currentFile = new File(filePath).getAbsoluteFile();
+		File target=new File("failingIntegrationTests");
+		if(!target.equals(currentFile.getParentFile())){
+			Files.copy(currentFile, new File(target, currentFile.getName()));
+		}
 	}
 
 	@Test

--- a/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
+++ b/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
@@ -68,4 +68,20 @@ class GrammarRegressions {
 		val blaAssignment=(model.expressions.get(0) as Assignment)
 		Assert.assertTrue(blaAssignment.value.class.simpleName, blaAssignment.value instanceof Reference)
 	}
+
+	@Test
+	//adapted from problematic snippet vertically-aligned-dynamics-and-textscripts
+	def void recognizeAssignmentAfterSchemeNumberValue() throws Exception {
+		val model='''
+			\markup \vspace #1 %avoid LSR-bug
+
+			music = "music"
+		'''.parse
+
+		model.assertNoErrors
+
+		val expectedMusicAssignment=model.expressions.last
+		Assert.assertTrue(expectedMusicAssignment instanceof Assignment)
+		Assert.assertEquals("music", (expectedMusicAssignment as Assignment).name)
+	}
 }

--- a/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
+++ b/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
@@ -84,4 +84,13 @@ class GrammarRegressions {
 		Assert.assertTrue(expectedMusicAssignment instanceof Assignment)
 		Assert.assertEquals("music", (expectedMusicAssignment as Assignment).name)
 	}
+
+	@Test
+	def void quoteatEndOfInSchemListOK() throws Exception {
+		val model='''
+			cnine=\markup\keys #'(c e  g bes d')
+		'''.parse
+
+		model.assertNoErrors
+	}
 }

--- a/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
+++ b/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
@@ -86,7 +86,7 @@ class GrammarRegressions {
 	}
 
 	@Test
-	def void quoteatEndOfInSchemListOK() throws Exception {
+	def void quoteAtEndOfSchemeListOK() throws Exception {
 		val model='''
 			cnine=\markup\keys #'(c e  g bes d')
 		'''.parse

--- a/org.elysium.ui/src/org/elysium/ui/labeling/LilyPondLabelProvider.java
+++ b/org.elysium.ui/src/org/elysium/ui/labeling/LilyPondLabelProvider.java
@@ -1,6 +1,7 @@
 package org.elysium.ui.labeling;
 
 import java.text.MessageFormat;
+
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.ui.label.DefaultEObjectLabelProvider;
@@ -8,7 +9,6 @@ import org.elysium.LilyPondConstants;
 import org.elysium.lilypond.Assignment;
 import org.elysium.lilypond.NewContext;
 import org.elysium.lilypond.Other;
-import org.elysium.lilypond.PropertyAssignment;
 import org.elysium.lilypond.Reference;
 import org.elysium.lilypond.Scheme;
 import org.elysium.lilypond.SchemeExpression;
@@ -53,9 +53,9 @@ public class LilyPondLabelProvider extends DefaultEObjectLabelProvider {
 		return assignment.getName();
 	}
 
-	public String text(PropertyAssignment propertyAssignment) {
-		return propertyAssignment.getId();
-	}
+//	public String text(PropertyAssignment propertyAssignment) {
+//		return propertyAssignment.getId();
+//	}
 
 	public String text(SpecialCommand specialCommand) {
 		return LilyPondConstants.BACKSLASH + specialCommand.getKeyword();

--- a/org.elysium/src/org/elysium/LilyPond.xtext
+++ b/org.elysium/src/org/elysium/LilyPond.xtext
@@ -98,11 +98,13 @@ SpecialCommandName: "include" | "version" | "sourcefilename" | "sourcefileline" 
 // Scheme
 
 Scheme hidden(WS, SL_COMMENT, ML_COMMENT, SCHEME_SL_COMMENT, SCHEME_ML_COMMENT, NL_NOINDENT): ("#" | "$") value=SchemeExpression;
-MarkupCommandScheme returns Scheme hidden(WS, SL_COMMENT, ML_COMMENT, SCHEME_SL_COMMENT, SCHEME_ML_COMMENT): ("#" | "$") value=SchemeExpression;
+MarkupCommandScheme returns Scheme hidden(WS, SL_COMMENT, ML_COMMENT, SCHEME_SL_COMMENT, SCHEME_ML_COMMENT): ("#" | "$") value=MarkupSchemeExpression;
 
 SchemeExpression: quotations+=("'" | "`" | "," | "@")* reference?="$"? value=SchemeValue;
+MarkupSchemeExpression returns SchemeExpression: quotations+=("'" | "`" | "," | "@")* reference?="$"? value=MarkupSchemeValue;
 
 SchemeValue: SchemeBoolean | SchemeList | SchemeBlock | SchemeCharacter | SchemeNumber | SchemeText | SchemeMarkupCommand;
+MarkupSchemeValue returns SchemeValue: SchemeBoolean | SchemeList | SchemeBlock | SchemeCharacter /*| SchemeNumber*/ | SchemeText | SchemeMarkupCommand;
 
 SchemeBoolean: value=SchemeBooleanValue;
 

--- a/org.elysium/src/org/elysium/LilyPond.xtext
+++ b/org.elysium/src/org/elysium/LilyPond.xtext
@@ -108,7 +108,7 @@ SchemeBoolean: value=SchemeBooleanValue;
 
 SchemeBooleanValue returns ecore::EBoolean: "#" ID;
 
-SchemeList: {SchemeList} vector?="#"? "(" expressions+=SchemeExpression* ")";
+SchemeList: {SchemeList} vector?="#"? "(" expressions+=SchemeExpression* ("'" | ",")* ")";
 
 SchemeBlock: "#{" elements+=Expression+ "#}";
 

--- a/org.elysium/src/org/elysium/LilyPond.xtext
+++ b/org.elysium/src/org/elysium/LilyPond.xtext
@@ -18,9 +18,7 @@ Expression: Assignment | CommonExpression;
 
 CommonExpression: Command | Block | Scheme | Number | Text;
 
-Assignment: name=(ID | STRING | SpecialCommandName) "=" value=Expression;
-
-PropertyAssignment: id=SchemeIdentifier "=" value=Expression;
+Assignment: name=(SchemeIdentifier | STRING) "=" value=Expression;
 
 Block: SimpleBlock | SimultaneousBlock;
 
@@ -34,11 +32,11 @@ SpecialCharacter: "!" | "?" | "+" | "<" | ">" | "[" | "]" | "~";
 
 UnparsedBlock: {UnparsedBlock} "{" expressions+=UnparsedExpression* "}";
 
-UnparsedExpression: BlockCommand | Include | PropertyAssignment | UnparsedCommand | UnparsedBlock | Scheme | Number | Text;
+UnparsedExpression: BlockCommand | Include | Assignment | UnparsedCommand | UnparsedBlock | Scheme | Number | Text;
 
 UnparsedCommand: "\\" command=(SchemeIdentifier | SpecialCommandName);
 
-Reference: "\\" assignment=[Assignment];
+Reference: "\\" assignment=[Assignment|SchemeIdentifier];
 
 Text: value=(SchemeTextValueSegment | "(" | ")" | "'" | "," | ":");
 

--- a/org.elysium/src/org/elysium/LilyPondRuntimeModule.java
+++ b/org.elysium/src/org/elysium/LilyPondRuntimeModule.java
@@ -11,7 +11,9 @@ import org.elysium.importuri.ILilyPondPathProvider;
 import org.elysium.importuri.LilyPondImportUriResolver;
 import org.elysium.resource.LilyPondResourceDescriptionStrategy;
 import org.elysium.scoping.LilyPondImportUriGlobalScopeProvider;
+import org.elysium.scoping.LilyPondSimpleLocalScopeProvider;
 import org.elysium.validation.LilyPondNamesAreUniqueValidationHelper;
+
 import com.google.inject.Binder;
 
 /**
@@ -26,6 +28,11 @@ public class LilyPondRuntimeModule extends AbstractLilyPondRuntimeModule {
 		binder.bind(ImportUriResolver.class).to(LilyPondImportUriResolver.class);
 		binder.bind(ILilyPondPathProvider.class).to(DefaultLilyPondPathProvider.class);
 		binder.bind(INamesAreUniqueValidationHelper.class).to(LilyPondNamesAreUniqueValidationHelper.class);
+	}
+
+	@Override
+	public void configureIScopeProviderDelegate(com.google.inject.Binder binder) {
+		binder.bind(org.eclipse.xtext.scoping.IScopeProvider.class).annotatedWith(com.google.inject.name.Names.named(org.eclipse.xtext.scoping.impl.AbstractDeclarativeScopeProvider.NAMED_DELEGATE)).to(LilyPondSimpleLocalScopeProvider.class);
 	}
 
 	@Override

--- a/org.elysium/src/org/elysium/formatting/LilyPondFormatter.java
+++ b/org.elysium/src/org/elysium/formatting/LilyPondFormatter.java
@@ -35,7 +35,7 @@ public class LilyPondFormatter extends AbstractDeclarativeFormatter {
 		config.setLinewrap().after(grammar.getIncludeRule());
 		config.setLinewrap(2).after(grammar.getVersionRule());
 		config.setLinewrap(2).after(grammar.getAssignmentRule());
-		config.setLinewrap().after(grammar.getPropertyAssignmentRule());
+//		config.setLinewrap().after(grammar.getPropertyAssignmentRule());
 		// Blocks
 		for (String[] blockKeywordPair : BLOCK_KEYWORD_PAIRS) {
 			for (Pair<Keyword, Keyword> pair : grammar.findKeywordPairs(blockKeywordPair[0], blockKeywordPair[1])) {

--- a/org.elysium/src/org/elysium/resource/LilyPondResourceDescriptionStrategy.java
+++ b/org.elysium/src/org/elysium/resource/LilyPondResourceDescriptionStrategy.java
@@ -18,8 +18,7 @@ import org.elysium.lilypond.LilyPond;
 public class LilyPondResourceDescriptionStrategy extends DefaultResourceDescriptionStrategy {
 
 	@Override
-	//only root assignmnets are visible to the outside
-	//TODO: please confirm that index is not needed for click and point; for me it worked without the user data!
+	//only root assignments are visible to the outside
 	public boolean createEObjectDescriptions(EObject eObject, IAcceptor<IEObjectDescription> acceptor) {
 		if (getQualifiedNameProvider() == null) {
 			return false;
@@ -38,7 +37,8 @@ public class LilyPondResourceDescriptionStrategy extends DefaultResourceDescript
 		}
 	}
 
-	//this could be more sophisticated; e.g. consider only semantic changes
+	//TODO: more sophisticated recompile indicator
+	//using click and point positions; see pull request #84 
 	private String getRecompileIndicatorHash(LilyPond eObject) {
 		return ""+NodeModelUtils.findActualNodeFor(eObject).getText().hashCode();
 	}

--- a/org.elysium/src/org/elysium/resource/LilyPondResourceDescriptionStrategy.java
+++ b/org.elysium/src/org/elysium/resource/LilyPondResourceDescriptionStrategy.java
@@ -1,16 +1,15 @@
 package org.elysium.resource;
 
-import java.util.Map;
-import org.eclipse.emf.ecore.EAttribute;
+import java.util.HashMap;
+
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.xtext.naming.QualifiedName;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.EObjectDescription;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.impl.DefaultResourceDescriptionStrategy;
 import org.eclipse.xtext.util.IAcceptor;
-import com.google.common.collect.Maps;
+import org.elysium.lilypond.Assignment;
+import org.elysium.lilypond.LilyPond;
 
 /**
  * Exports {@link EObjectDescription}s from LilyPond files. If these haven't
@@ -19,24 +18,28 @@ import com.google.common.collect.Maps;
 public class LilyPondResourceDescriptionStrategy extends DefaultResourceDescriptionStrategy {
 
 	@Override
+	//only root assignmnets are visible to the outside
+	//TODO: please confirm that index is not needed for click and point; for me it worked without the user data!
 	public boolean createEObjectDescriptions(EObject eObject, IAcceptor<IEObjectDescription> acceptor) {
 		if (getQualifiedNameProvider() == null) {
 			return false;
 		}
-		QualifiedName qualifiedName = getQualifiedNameProvider().getFullyQualifiedName(eObject);
-		if (qualifiedName == null) {
-			qualifiedName = QualifiedName.create(EcoreUtil.getURI(eObject).fragment());
+		if(eObject instanceof LilyPond){
+			String recompileIndicatorHash=getRecompileIndicatorHash((LilyPond)eObject);
+			HashMap<String, String> userData=new HashMap<String, String>();
+			userData.put("recompileHash", recompileIndicatorHash);
+			acceptor.accept(EObjectDescription.create(eObject.eResource().getURI().toString(), eObject, userData));
+			return true;
+		}else if(eObject instanceof Assignment){
+			acceptor.accept(EObjectDescription.create(getQualifiedNameProvider().getFullyQualifiedName(eObject), eObject));
+			return false;
+		}else{
+			return false;
 		}
-		// Include attributes
-		Map<String, String> userData = Maps.newHashMap();
-		for (EAttribute attribute : eObject.eClass().getEAllAttributes()) {
-			Object value = eObject.eGet(attribute);
-			userData.put(attribute.getName(), value == null ? "" : value.toString());
-		}
-		// Offset for point & click
-		userData.put(".offset", String.valueOf(NodeModelUtils.findActualNodeFor(eObject).getOffset())); //$NON-NLS-1$
-		acceptor.accept(EObjectDescription.create(qualifiedName, eObject, userData));
-		return true;
 	}
 
+	//this could be more sophisticated; e.g. consider only semantic changes
+	private String getRecompileIndicatorHash(LilyPond eObject) {
+		return ""+NodeModelUtils.findActualNodeFor(eObject).getText().hashCode();
+	}
 }

--- a/org.elysium/src/org/elysium/scoping/LilyPondScopeProvider.java
+++ b/org.elysium/src/org/elysium/scoping/LilyPondScopeProvider.java
@@ -1,9 +1,45 @@
 package org.elysium.scoping;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.EReference;
+import org.eclipse.xtext.scoping.IScope;
+import org.eclipse.xtext.scoping.Scopes;
 import org.eclipse.xtext.scoping.impl.AbstractDeclarativeScopeProvider;
+import org.elysium.lilypond.Assignment;
+import org.elysium.lilypond.Block;
+import org.elysium.lilypond.SchemeBlock;
+import org.elysium.lilypond.UnparsedBlock;
 
 /**
  * Scoping definition for the LilyPond language.
+ * Assignments within blocks are locally visible within that block
+ * 
+ * root assignmets are dealt with in the named delegate LilyPondSimpleLocalScopeProvider
  */
 public class LilyPondScopeProvider extends AbstractDeclarativeScopeProvider {
+
+	private IScope createAssignmentBlockScope(EObject block, EReference ref){
+		List<Assignment> defs=new ArrayList<Assignment>();
+		for (EObject element : block.eContents()) {
+			if(element instanceof Assignment){
+				defs.add((Assignment)element);
+			}
+		}
+		return Scopes.scopeFor(defs, getScope(block.eContainer(), ref));
+	}
+
+	public IScope scope_Assignment(UnparsedBlock context, EReference ref){
+		return createAssignmentBlockScope(context, ref);
+	}
+
+	public IScope scope_Assignment(Block context, EReference ref){
+		return createAssignmentBlockScope(context, ref);
+	}
+
+	public IScope scope_Assignment(SchemeBlock context, EReference ref){
+		return createAssignmentBlockScope(context, ref);
+	}
 }

--- a/org.elysium/src/org/elysium/scoping/LilyPondSimpleLocalScopeProvider.java
+++ b/org.elysium/src/org/elysium/scoping/LilyPondSimpleLocalScopeProvider.java
@@ -1,0 +1,37 @@
+package org.elysium.scoping;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.xtext.resource.IEObjectDescription;
+import org.eclipse.xtext.resource.ISelectable;
+import org.eclipse.xtext.scoping.Scopes;
+import org.eclipse.xtext.scoping.impl.MultimapBasedSelectable;
+import org.eclipse.xtext.scoping.impl.SimpleLocalScopeProvider;
+import org.elysium.lilypond.Assignment;
+
+/**
+ * the default simple local scope provider implementation makes everything named within a resource referrable
+ * this is not the case for LilyPond files 
+ */
+public class LilyPondSimpleLocalScopeProvider extends SimpleLocalScopeProvider{
+
+	@Override
+	//only root assignmets are visible - assignments within blocks are dealt with in LilyPondScopeProvider
+	protected ISelectable getAllDescriptions(Resource resource) {
+		List<Assignment> assignments=new ArrayList<Assignment>();
+		if(!resource.getContents().isEmpty()){
+			EList<EObject> candidates = resource.getContents().get(0).eContents();
+			for (EObject eObject : candidates) {
+				if(eObject instanceof Assignment){
+					assignments.add((Assignment)eObject);
+				}
+			}
+		}
+		Iterable<IEObjectDescription> allDescriptions = Scopes.scopedElementsFor(assignments, getNameProvider());
+		return new MultimapBasedSelectable(allDescriptions);
+	}
+}


### PR DESCRIPTION
I have made changes to the indexing and scoping, in particular eliminating the PropertyAssignment (for some reason it was impossible to give both assignment types a common super type - all attempts lead to compile errors in the generated code).

SchemeIdentifier-like names seem to be valid for assignmnets - at least LilyPond accepted
my-UpBow = \upbow

If there are restrictions in that direction, it is much easier to deal with them in the validator than in the grammar.

Please comment on the modifications in the LilyPondResourceDescriptionStrategy. I could not find a reason to put all elements in the index. Click and point worked with the simplified version as well. This way the index is much smaller and much faster to build (improved performance for the integrationtests).