### PR TITLE
add simple scheme define (aliases)

### DIFF
--- a/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
+++ b/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
@@ -31,11 +31,12 @@ class GrammarRegressions {
 		//using-make-connected-path-stencil-to-draw-custom-shapes.ly
 		//flamenco-notation.ly
 		val problemCases=#["#()","#ff"]
+		val bar="bar"
 		problemCases.forEach[problem|
 			val model='''
 				foo = \markup «problem»
 
-				bar = "x"
+				«bar» = "x"
 			'''.parse
 	
 			model.assertNoErrors
@@ -43,25 +44,26 @@ class GrammarRegressions {
 			val foo=model.expressions.head
 			Assert.assertTrue(problem, foo instanceof Assignment)
 	
-			val bar=model.expressions.last
-			Assert.assertTrue(problem, bar instanceof Assignment)
-			Assert.assertEquals(problem, "bar", (bar as Assignment).name)
+			val barModel=model.expressions.last
+			Assert.assertTrue(problem, barModel instanceof Assignment)
+			Assert.assertEquals(problem, bar, (barModel as Assignment).name)
 		]
 	}
 
 	@Test
 	def void assignmentInExpression() throws Exception {
 		//from displaying-the-version-number-with-conditionals-if-then-using-scheme
+		val pieceTagLine="pieceTagLine"
 		val model='''
 			#(if (not (defined? 'pieceTagLine))
-			  (define pieceTagLine (string-append "You are running version " (lilypond-version))))
+			  (define «pieceTagLine» (string-append "You are running version " (lilypond-version))))
 		'''.parse
 
 		val AtomicBoolean pieceTagLineFound=new AtomicBoolean(false)
 		model.assertNoErrors
 		model.eAllContents.forEach[
 			if(it instanceof Assignment){
-				if((it as Assignment).name=="pieceTagLine"){
+				if((it as Assignment).name==pieceTagLine){
 					pieceTagLineFound.set(true)
 				}
 			}
@@ -71,9 +73,10 @@ class GrammarRegressions {
 
 	@Test
 	def void schemeAliasDefine() throws Exception {
+		val alias = "anAlias"
 		val model='''
-			#(define anAlias something)
-			refersTo = \anAlias
+			#(define «alias» something)
+			refersTo = \«alias»
 		'''.parse
 
 		model.assertNoErrors
@@ -85,23 +88,24 @@ class GrammarRegressions {
 		Assert.assertTrue(referencingAssignment instanceof Assignment)
 		val ref=(referencingAssignment as Assignment).value
 		Assert.assertTrue(ref.toString,ref instanceof Reference)
-		Assert.assertEquals("anAlias", (ref as Reference).assignment.name)
+		Assert.assertEquals(alias, (ref as Reference).assignment.name)
 	}
 
 	@Test
 	//regression test for #58
 	def void recognizeTrill() throws Exception {
+		val trill="trill"
 		val model='''
 			thumb = \finger \markup \scale #(cons (magstep 5) (magstep 5))
 			                        \musicglyph #"scripts.thumb"
-			trill = #(make-articulation "trill")
+			«trill» = #(make-articulation "trill")
 		'''.parse
 
 		model.assertNoErrors
 
 		val expectedTrillAssignment=model.expressions.last
 		Assert.assertTrue(expectedTrillAssignment instanceof Assignment)
-		Assert.assertEquals("trill", (expectedTrillAssignment as Assignment).name)
+		Assert.assertEquals(trill, (expectedTrillAssignment as Assignment).name)
 	}
 
 	@Test
@@ -136,17 +140,18 @@ class GrammarRegressions {
 	@Test
 	//adapted from problematic snippet vertically-aligned-dynamics-and-textscripts
 	def void recognizeAssignmentAfterSchemeNumberValue() throws Exception {
+		val music="music"
 		val model='''
 			\markup \vspace #1 %avoid LSR-bug
 
-			music = "music"
+			music = "«music»"
 		'''.parse
 
 		model.assertNoErrors
 
 		val expectedMusicAssignment=model.expressions.last
 		Assert.assertTrue(expectedMusicAssignment instanceof Assignment)
-		Assert.assertEquals("music", (expectedMusicAssignment as Assignment).name)
+		Assert.assertEquals(music, (expectedMusicAssignment as Assignment).name)
 	}
 
 	@Test

--- a/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
+++ b/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
@@ -25,6 +25,25 @@ class GrammarRegressions {
 	extension ValidationTestHelper validator
 
 	@Test
+	def void schemeAliasDefine() throws Exception {
+		val model='''
+			#(define anAlias something)
+			refersTo = \anAlias
+		'''.parse
+
+		model.assertNoErrors
+
+		val define=model.expressions.head
+		Assert.assertTrue(define instanceof Assignment)
+
+		val referencingAssignment=model.expressions.last
+		Assert.assertTrue(referencingAssignment instanceof Assignment)
+		val ref=(referencingAssignment as Assignment).value
+		Assert.assertTrue(ref.toString,ref instanceof Reference)
+		Assert.assertEquals("anAlias", (ref as Reference).assignment.name)
+	}
+
+	@Test
 	//regression test for #58
 	def void recognizeTrill() throws Exception {
 		val model='''

--- a/org.elysium/src/org/elysium/LilyPond.xtext
+++ b/org.elysium/src/org/elysium/LilyPond.xtext
@@ -45,7 +45,7 @@ Number: value=INT;
 
 // Commands
 
-SpecialCommand: Include | Version | SourceFileName | SourceFileLine | Markup | MarkupLines | BlockCommand | OutputDefinition | RelativeMusic | TransposedMusic | ModeChange | MusicWithLyrics | NewContext | ContextDef | Other;
+SpecialCommand: Include | Version | SourceFileName | SourceFileLine | Markup | MarkupLines | MarkupList | BlockCommand | OutputDefinition | RelativeMusic | TransposedMusic | ModeChange | MusicWithLyrics | NewContext | ContextDef | Other;
 
 Include: "\\" keyword="include" importURI=STRING;
 
@@ -58,6 +58,8 @@ SourceFileLine: "\\" keyword="sourcefileline" line=INT;
 Markup: "\\" keyword="markup" body=MarkupBody; // XXX very messy 
 
 MarkupLines: "\\" keyword="markuplines" body=MarkupBody;
+
+MarkupList: "\\" keyword=("markuplist") body=MarkupBody;
 
 //I split up Scheme/SchemeText, using special definitions for the MarkupBody-Command-case
 //so that I can enforce different hidden-Definitions
@@ -92,7 +94,7 @@ Other: "\\" keyword=(SpecialCharacter | "(" | ")" | OtherName);
 
 OtherName: "accepts" | "addlyrics" | "alias" | "alternative" | "change" | "chords" | "consists" | "default" | "defaultchild" | "denies" | "description" | "drums" | "figures" | "lyrics" | "maininput" | "name" | "objectid" | "octave" | "override" | "remove" | "repeat" | "rest" | "revert" | "sequential" | "set" | "simultaneous" | "tempo" | "type" | "unset" | "with";
 
-SpecialCommandName: "define" | "include" | "version" | "sourcefilename" | "sourcefileline" | "markup" | "markuplines" | "book" | "bookpart" | "context" | "header" | "score" | "paper" | "midi" | "layout" | "relative" | "transpose" | "chordmode" | "drummode" | "figuremode" | "lyricmode" | "notemode" | "lyricsto" | "new" | "with" | OtherName; // XXX this must duplicate all known commands 
+SpecialCommandName: "define" | "include" | "version" | "sourcefilename" | "sourcefileline" | "markup" | "markuplines" | "markuplist" | "book" | "bookpart" | "context" | "header" | "score" | "paper" | "midi" | "layout" | "relative" | "transpose" | "chordmode" | "drummode" | "figuremode" | "lyricmode" | "notemode" | "lyricsto" | "new" | "with" | OtherName; // XXX this must duplicate all known commands 
 
 // Scheme
 

--- a/org.elysium/src/org/elysium/LilyPond.xtext
+++ b/org.elysium/src/org/elysium/LilyPond.xtext
@@ -14,11 +14,12 @@ import "http://www.eclipse.org/emf/2002/Ecore" as ecore
 
 LilyPond: expressions+=Expression*;
 
-Expression: Assignment | CommonExpression;
+Expression: Assignment | SimpleSchemeAssignment | CommonExpression;
 
 CommonExpression: Command | Block | Scheme | Number | Text;
 
 Assignment: name=(SchemeIdentifier | STRING) "=" value=Expression;
+SimpleSchemeAssignment returns Assignment: "#" "(" "define" name=ID value=Text ")";
 
 Block: SimpleBlock | SimultaneousBlock;
 
@@ -91,7 +92,7 @@ Other: "\\" keyword=(SpecialCharacter | "(" | ")" | OtherName);
 
 OtherName: "accepts" | "addlyrics" | "alias" | "alternative" | "change" | "chords" | "consists" | "default" | "defaultchild" | "denies" | "description" | "drums" | "figures" | "lyrics" | "maininput" | "name" | "objectid" | "octave" | "override" | "remove" | "repeat" | "rest" | "revert" | "sequential" | "set" | "simultaneous" | "tempo" | "type" | "unset" | "with";
 
-SpecialCommandName: "include" | "version" | "sourcefilename" | "sourcefileline" | "markup" | "markuplines" | "book" | "bookpart" | "context" | "header" | "score" | "paper" | "midi" | "layout" | "relative" | "transpose" | "chordmode" | "drummode" | "figuremode" | "lyricmode" | "notemode" | "lyricsto" | "new" | "with" | OtherName; // XXX this must duplicate all known commands 
+SpecialCommandName: "define" | "include" | "version" | "sourcefilename" | "sourcefileline" | "markup" | "markuplines" | "book" | "bookpart" | "context" | "header" | "score" | "paper" | "midi" | "layout" | "relative" | "transpose" | "chordmode" | "drummode" | "figuremode" | "lyricmode" | "notemode" | "lyricsto" | "new" | "with" | OtherName; // XXX this must duplicate all known commands 
 
 // Scheme
 


### PR DESCRIPTION
simple scheme defines referrable as assignments, allowing two more integration test cases to pass

I am not sure what name and value may look like, so the SimpleSchemeAssignment rule may still be refined