### PR TITLE
fix #96 - problems with include filenames containing space

### DIFF
--- a/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
+++ b/org.elysium.test/src/org/elysium/test/regression/GrammarRegressions.xtend
@@ -359,7 +359,7 @@ class GrammarRegressions {
 
 	@Test
 	def void assignmentIncluded() {
-		val filename = "foo.ly";
+		val filename = "1 foo.ly";
 		Files.writeStringIntoFile(filename, ASSIGNMENT);
 		'''
 			\include "«filename»"

--- a/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondHyperlinkHelper.java
+++ b/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondHyperlinkHelper.java
@@ -71,7 +71,8 @@ public class LilyPondHyperlinkHelper extends HyperlinkHelper {
 					if (includedResource != null) {
 						uriToOpen = includedEResource.getURI();
 					}
-				}else{
+				}
+				if(uriToOpen==null){
 					uriToOpen=URI.createURI(uriResolver.resolve(include));
 					if(!uriToOpen.isFile() || uriToOpen.isRelative()){
 						uriToOpen=null;


### PR DESCRIPTION
I restricted resolving the URI differently to Windows. On my Mac URI.create("1 foo.ly") does not throw an exception. On my Windows machine, it does.