### PR TITLE
exclude .ily from comlpete compilation and speed up build process

### DIFF
--- a/org.elysium.ui/src/org/elysium/ui/compiler/CancellableProcessUtils.java
+++ b/org.elysium.ui/src/org/elysium/ui/compiler/CancellableProcessUtils.java
@@ -20,7 +20,7 @@ public class CancellableProcessUtils {
 	 * Runs a process synchronously described by the given process builder and
 	 * processes the lines of its output with the given output processor.
 	 */
-	public static void runCancellableProcess(final ProcessBuilder processBuilder, final OutputProcessor outputProcessor, final IProgressMonitor monitor) throws IOException, InterruptedException {
+	public static void runCancellableProcess(final ProcessBuilder processBuilder, final OutputProcessor outputProcessor, final IProgressMonitor monitor, final String processName) throws IOException, InterruptedException {
 		final AtomicBoolean done=new AtomicBoolean(false);
 
 		final Process process = processBuilder.start();
@@ -39,7 +39,7 @@ public class CancellableProcessUtils {
 					}
 				}
 			}
-		}).start();
+		}, "Canceller for "+processName).start();
 
 		try{
 			new Thread(new Runnable() {
@@ -58,7 +58,7 @@ public class CancellableProcessUtils {
 					}
 				}
 				
-			}).start();
+			}, processName).start();
 			process.waitFor();
 		}catch(RuntimeException e){
 			if(e.getCause() instanceof IOException){

--- a/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
+++ b/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
@@ -35,6 +35,7 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.progress.IProgressConstants;
 import org.eclipse.util.EditorUtils;
 import org.eclipse.util.UiUtils;
+import org.elysium.LilyPondConstants;
 import org.elysium.ui.Activator;
 import org.elysium.ui.compiler.outdated.OutdatedDecorator;
 import org.elysium.ui.compiler.updater.SyntaxUpdaterOutputProcessor;
@@ -68,36 +69,42 @@ public class CompilerJob extends Job {
 		IStatus returnStatus=Status.OK_STATUS;
 		monitor.beginTask("LilyPond Compilation", 4);
 		try {
+			boolean fullCompile=LilyPondConstants.EXTENSION.equals(file.getFileExtension());
 			checkCancelled(monitor);
-			console.setMonitor(monitor);
-			console.clearConsole();
-			console.firePropertyChange(this, IConsoleConstants.P_CONSOLE_OUTPUT_COMPLETE, null, false);
+			if(fullCompile){
+				console.setMonitor(monitor);
+				console.clearConsole();
+				console.firePropertyChange(this, IConsoleConstants.P_CONSOLE_OUTPUT_COMPLETE, null, false);
+			}
 
 			long start = System.currentTimeMillis();
 			preprocess(monitor);
 
 			checkCancelled(monitor);
-			monitor.subTask("prepare LilyPond processing");
-			ProcessBuilder processBuilder = CompilerProcessBuilderFactory.get(file);
-			prepareProcessBuilder(processBuilder);
-
-			OutputProcessor outputProcessor = new CompilerOutputProcessor(file, console);
-			monitor.worked(1);
-			monitor.subTask("LilyPond processing");
-			try {
-				CancellableProcessUtils.runCancellableProcess(processBuilder, outputProcessor, monitor);
-			} catch (IOException e) {
-				handleInvalidExecutablePath();
+			if (fullCompile){
+				monitor.subTask("prepare LilyPond processing");
+				ProcessBuilder processBuilder = CompilerProcessBuilderFactory.get(file);
+				prepareProcessBuilder(processBuilder);
+		
+				OutputProcessor outputProcessor = new CompilerOutputProcessor(file, console);
+				monitor.worked(1);
+				monitor.subTask("LilyPond processing");
+				try {
+					CancellableProcessUtils.runCancellableProcess(processBuilder, outputProcessor, monitor);
+				} catch (IOException e) {
+					handleInvalidExecutablePath();
+				}
 			}
 			monitor.worked(1);
 
 			postprocess(monitor);
-			long stop = System.currentTimeMillis();
-
-			float executionTimeInSeconds = (stop - start) / 1000f;
-			console.printMeta(MessageFormat.format("LilyPond terminated in {0} seconds.", executionTimeInSeconds));
-			console.firePropertyChange(this, IConsoleConstants.P_CONSOLE_OUTPUT_COMPLETE, null, true);
-
+			if(fullCompile){
+				long stop = System.currentTimeMillis();
+	
+				float executionTimeInSeconds = (stop - start) / 1000f;
+				console.printMeta(MessageFormat.format("LilyPond terminated in {0} seconds.", executionTimeInSeconds));
+				console.firePropertyChange(this, IConsoleConstants.P_CONSOLE_OUTPUT_COMPLETE, null, true);
+			}
 			scheduleProjectRefresh();
 			monitor.done();
 		} catch(OperationCanceledException e){

--- a/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
+++ b/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
@@ -67,7 +67,7 @@ public class CompilerJob extends Job {
 	@Override
 	protected IStatus run(final IProgressMonitor monitor) {
 		IStatus returnStatus=Status.OK_STATUS;
-		monitor.beginTask("LilyPond Compilation", 4);
+		monitor.beginTask("LilyPond Compilation: "+file.getName(), 4);
 		try {
 			boolean fullCompile=LilyPondConstants.EXTENSION.equals(file.getFileExtension());
 			checkCancelled(monitor);
@@ -90,7 +90,7 @@ public class CompilerJob extends Job {
 				monitor.worked(1);
 				monitor.subTask("LilyPond processing");
 				try {
-					CancellableProcessUtils.runCancellableProcess(processBuilder, outputProcessor, monitor);
+					CancellableProcessUtils.runCancellableProcess(processBuilder, outputProcessor, monitor, "compile "+file.getName());
 				} catch (IOException e) {
 					handleInvalidExecutablePath();
 				}
@@ -204,7 +204,7 @@ public class CompilerJob extends Job {
 
 			OutputProcessor outputProcessor = new SyntaxUpdaterOutputProcessor(console);
 
-			CancellableProcessUtils.runCancellableProcess(processBuilder, outputProcessor, monitor);
+			CancellableProcessUtils.runCancellableProcess(processBuilder, outputProcessor, monitor, "update syntax "+file.getName());
 		} catch (Exception e) {
 			Activator.logError("Couldn't update syntax before compiling", e);
 		}

--- a/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
+++ b/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
@@ -3,8 +3,12 @@ package org.elysium.ui.compiler;
 import static org.elysium.ui.compiler.CompilerJob.removeOutdatedMarker;
 import static org.elysium.ui.markers.MarkerTypes.UP_TO_DATE;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -18,6 +22,7 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
 import org.eclipse.emf.util.ResourceUtils;
 import org.eclipse.xtext.EcoreUtil2;
@@ -56,14 +61,26 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 				}
 			}
 		}
-		compile(filesToCompile);
-		removeOutdatedMarkers(filesMarkedAsOutdated);
+		ResourceSet rs=new ResourceSetImpl();
+		compile(filesToCompile, rs);
+		removeOutdatedMarkers(filesMarkedAsOutdated, rs);
 	}
 
 	public static void compile(Set<IFile> files) {
+		compile(files, new ResourceSetImpl());
+	}
+
+	private  static void compile(Set<IFile> files, ResourceSet resourceSetToUse) {
 		int maxParallelCalls = Activator.getInstance().getPreferenceStore().getInt(CompilerPreferenceConstants.PARALLEL_COMPILES.name());
-		addAllIncludingFiles(files);
-		for (IFile file : files) {
+		addAllIncludingFiles(files,resourceSetToUse);
+		List<IFile> sortedFiles=new ArrayList<IFile>(files);
+		Collections.sort(sortedFiles, new Comparator<IFile>() {
+			@Override
+			public int compare(IFile o1, IFile o2) {
+				return o1.getFileExtension().compareTo(o2.getFileExtension());
+			}
+		});
+		for (IFile file : sortedFiles) {
 			CompilerJob compilerJob = new CompilerJob(file);
 			Job[] oldCompilerJobs = Job.getJobManager().find(compilerJob);
 			for (Job oldCompilerJob : oldCompilerJobs) {
@@ -76,8 +93,8 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 		}
 	}
 
-	private static void removeOutdatedMarkers(final Set<IFile> files) throws CoreException {
-		addAllIncludingFiles(files);
+	private static void removeOutdatedMarkers(final Set<IFile> files, ResourceSet resourceSetToUse) throws CoreException {
+		addAllIncludingFiles(files, resourceSetToUse);
 		for (IFile file : files) {
 			removeOutdatedMarker(file);
 			file.createMarker(UP_TO_DATE); // Prevent readding outdated marker
@@ -89,6 +106,10 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 	 * indirectly) include any file in the list.
 	 */
 	public static void addAllIncludingFiles(Set<IFile> files) {
+		addAllIncludingFiles(files, new ResourceSetImpl());
+	}
+
+	private static void addAllIncludingFiles(Set<IFile> files, ResourceSet resourceSetToUse) {
 		Set<IProject> projects = new HashSet<IProject>();
 		for (IFile file : files) {
 			projects.add(file.getProject());
@@ -96,9 +117,10 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 		for (IProject project : projects) {
 			projects.addAll(Arrays.asList(project.getReferencingProjects()));
 		}
+		Set<IFile> directIncludesAlreadyCalculated=new HashSet<IFile>();
 		for (IProject project : projects) {
 			for (IFile file : org.eclipse.util.ResourceUtils.getAllFiles(project)) {
-				addIfNecessary(file, files);
+				addIfNecessary(file, files, directIncludesAlreadyCalculated ,resourceSetToUse);
 			}
 		}
 	}
@@ -107,15 +129,19 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 	 * Adds the given file to the list of files to build if it (even indirectly)
 	 * includes any of the files to build.
 	 */
-	private static void addIfNecessary(IFile file, Set<IFile> filesToBuild) {
+	private static void addIfNecessary(IFile file, Set<IFile> filesToBuild, Set<IFile> directIncludesAlreadyCalculated, ResourceSet resourceSetToUse) {
 		if (!filesToBuild.contains(file) && LilyPondConstants.EXTENSIONS.contains(file.getFileExtension())) {
-			Set<IFile> includedFiles = getIncludedFiles(file);
+			if(directIncludesAlreadyCalculated.contains(file)){
+				return;
+			}
+			Set<IFile> includedFiles = getIncludedFiles(file, resourceSetToUse);
+			directIncludesAlreadyCalculated.add(file);
 			for (IFile includedFile : includedFiles) {
 				if (!includedFile.equals(file)) {
 					if (filesToBuild.contains(includedFile)) {
 						filesToBuild.add(file);
 					} else {
-						addIfNecessary(includedFile, filesToBuild);
+						addIfNecessary(includedFile, filesToBuild, directIncludesAlreadyCalculated, resourceSetToUse);
 						if (filesToBuild.contains(includedFile)) {
 							filesToBuild.add(file);
 						}
@@ -128,9 +154,9 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 	/**
 	 * Returns the files directly included in the given file.
 	 */
-	private static Set<IFile> getIncludedFiles(IFile file) {
+	private static Set<IFile> getIncludedFiles(IFile file, ResourceSet resourceSetToUse) {
 		Set<IFile> result = new HashSet<IFile>();
-		Resource eResource = new ResourceSetImpl().getResource(org.eclipse.emf.common.util.URI.createPlatformResourceURI(file.getFullPath().toString(), true), true);
+		Resource eResource = resourceSetToUse.getResource(org.eclipse.emf.common.util.URI.createPlatformResourceURI(file.getFullPath().toString(), true), true);
 		if (eResource != null) {
 			for (EObject eObject : EcoreUtil2.eAllContentsAsList(eResource)) {
 				if (eObject instanceof Include) {


### PR DESCRIPTION
This is a proposed fix for #95. The compile job for .ily files still has to be created in order to remove old markers but I removed all steps I thought to be unnecessary within the job. I sorted the files for compilation so that fast jobs (.ily) are handled first. This keeps the list of open jobs short (progress view).

Previously a new resource set was used for each direct include calculation. Changing that to one common resource set for each build speeds up the process. For the same reason I introduced the set of files for which this calculation has been done already (the filesToBuild-set does not quite serve the same purpose, it does not prevent duplicate calculation). As a result (on my slow Windows machine), the time for calculating allIncludingFiles dropped from 45 seconds to 4 seconds (for real-world/Mozart-KV250).