### PR TITLE
add Xmx parameter to workflow launch config

### DIFF
--- a/org.elysium/src/org/elysium/GenerateLilyPond.mwe2.launch
+++ b/org.elysium/src/org/elysium/GenerateLilyPond.mwe2.launch
@@ -11,4 +11,5 @@
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.eclipse.emf.mwe2.launch.runtime.Mwe2Launcher"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="src/org/elysium/GenerateLilyPond.mwe2"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="org.elysium"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Xmx1024m"/>
 </launchConfiguration>


### PR DESCRIPTION
The setup task fails if the default Xmx settings do not provide enough memory - explicitly set the value in the launch config.