### PR TITLE
Validation preference

### DIFF
--- a/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/importuri/ImportUriResolverTest.java
+++ b/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/importuri/ImportUriResolverTest.java
@@ -15,18 +15,27 @@ public class ImportUriResolverTest {
 	public void testAbsolute() {
 		checkIsAbsolute("", false);
 		checkIsAbsolute("file.ly", false);
+		checkIsAbsolute("fi le.ly", false);
 		checkIsAbsolute("folder/file.ly", false);
+		checkIsAbsolute("fol der/fi le.ly", false);
 		checkIsAbsolute("../file.ly", false);
+		checkIsAbsolute("../fi le.ly", false);
 		checkIsAbsolute("../otherFolder/file.ly", false);
+		checkIsAbsolute("../other Folder/fi le.ly", false);
 
 		
 		if(isWindows) {
 			checkIsAbsolute("c:/windowsfolder/file.ly", true);
+			checkIsAbsolute("c:/windows folder/fi le.ly", true);
 			checkIsAbsolute("c:\\windowsfolder\\file.ly", true);
+			checkIsAbsolute("c:\\windows folder\\fi le.ly", true);
 			checkIsAbsolute("c:\\\\windowsfolder\\\\file.ly", true);
+			checkIsAbsolute("c:\\\\windows folder\\\\fi le.ly", true);
 		}else {
 			checkIsAbsolute("/file.ly", true);
+			checkIsAbsolute("/fi le.ly", true);
 			checkIsAbsolute("/unixfolder/file.ly", true);
+			checkIsAbsolute("/unix folder/fi le.ly", true);
 		}
 	}
 

--- a/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/importuri/ImportUriResolverTest.java
+++ b/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/importuri/ImportUriResolverTest.java
@@ -1,0 +1,36 @@
+package org.elysium.tests.importuri;
+
+import org.elysium.importuri.LilyPondImportUriResolver;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+
+//TODO find a way to allow these tests to run system independent
+public class ImportUriResolverTest {
+
+	private boolean isWindows=Optional.fromNullable(System.getProperty("os.name")).or("another").toLowerCase().contains("win");//$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
+
+	@Test
+	public void testAbsolute() {
+		checkIsAbsolute("", false);
+		checkIsAbsolute("file.ly", false);
+		checkIsAbsolute("folder/file.ly", false);
+		checkIsAbsolute("../file.ly", false);
+		checkIsAbsolute("../otherFolder/file.ly", false);
+
+		
+		if(isWindows) {
+			checkIsAbsolute("c:/windowsfolder/file.ly", true);
+			checkIsAbsolute("c:\\windowsfolder\\file.ly", true);
+			checkIsAbsolute("c:\\\\windowsfolder\\\\file.ly", true);
+		}else {
+			checkIsAbsolute("/file.ly", true);
+			checkIsAbsolute("/unixfolder/file.ly", true);
+		}
+	}
+
+	private void checkIsAbsolute(String includeString, boolean expectedAbsolute) {
+		Assert.assertEquals(expectedAbsolute, LilyPondImportUriResolver.isAbsolute(includeString));
+	}
+}

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/preferences/LilyPondValidatorConfigBlock.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/preferences/LilyPondValidatorConfigBlock.java
@@ -47,6 +47,7 @@ public class LilyPondValidatorConfigBlock extends AbstractValidatorConfiguration
 		addComboBox(generalProblems, "include using variable", IssueCodes.VARIABLE_INCLUDE, defaultIndent, otherErrors, otherErrorLabels);
 
 		Composite linkingProblems = createSection("Linking", composite, nColumns);
+		addComboBox(linkingProblems, "absolute include", IssueCodes.ABSOLUTE_INCLUDE, defaultIndent, otherErrors, otherErrorLabels);
 		addComboBox(linkingProblems, "unresolvable include (.ly)", IssueCodes.UNRESOLVABLE_INCLUDE_STANDALONE, defaultIndent, otherErrors, otherErrorLabels);
 		addComboBox(linkingProblems, "unresolvable include (.ily...)", IssueCodes.UNRESOLVABLE_INCLUDE_ILY, defaultIndent, otherErrors, otherErrorLabels);
 		addComboBox(linkingProblems, "unknown variable (.ly)", IssueCodes.UNKNOWN_VARIABLE_STANDALONE, defaultIndent, linkingErrors, linkingErrorLabels);

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/preferences/LilyPondValidatorConfigBlock.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/preferences/LilyPondValidatorConfigBlock.java
@@ -25,11 +25,11 @@ import org.elysium.validation.IssueCodes;
 @SuppressWarnings("restriction")
 public class LilyPondValidatorConfigBlock extends AbstractValidatorConfigurationBlock {
 
-	private static final String[] linkingErrors=new String[]{"ignore","warning","error"};
-	private static final String[] linkingErrorLabels=new String[]{"Ignore","Warning","Error"};
+	private static final String[] linkingSeverities=new String[]{"ignore","warning","error"};
+	private static final String[] linkingSeverityLabels=new String[]{"Ignore","Warning","Error"};
 
-	private static final String[] otherErrors=new String[]{"ignore","info","warning","error"};
-	private static final String[] otherErrorLabels=new String[]{"Ignore","Info","Warning","Error"};
+	private static final String[] otherSeverities=new String[]{"ignore","info","warning","error"};
+	private static final String[] otherSeverityLabels=new String[]{"Ignore","Info","Warning","Error"};
 
 	LilyPondListEditor noLinkingErrorAssignments;
 	private IPreferenceStore preferenceStore;
@@ -41,17 +41,17 @@ public class LilyPondValidatorConfigBlock extends AbstractValidatorConfiguration
 	protected void fillSettingsPage(Composite composite, int nColumns, int defaultIndent) {
 
 		Composite generalProblems = createSection("General", composite, nColumns);
-		addComboBox(generalProblems, "no version (.ly)", IssueCodes.NO_VERSION_STANDALONE, defaultIndent, otherErrors, otherErrorLabels);
-		addComboBox(generalProblems, "no version (.ily...)", IssueCodes.NO_VERSION_ILY, defaultIndent, otherErrors, otherErrorLabels);
-		addComboBox(generalProblems, "duplicate variable", IssueCodes.DUPLICATE_VARIABLE, defaultIndent, otherErrors, otherErrorLabels);
-		addComboBox(generalProblems, "include using variable", IssueCodes.VARIABLE_INCLUDE, defaultIndent, otherErrors, otherErrorLabels);
+		addComboBox(generalProblems, "no version (.ly)", IssueCodes.NO_VERSION_STANDALONE, defaultIndent, otherSeverities, otherSeverityLabels);
+		addComboBox(generalProblems, "no version (.ily...)", IssueCodes.NO_VERSION_ILY, defaultIndent, otherSeverities, otherSeverityLabels);
+		addComboBox(generalProblems, "duplicate variable", IssueCodes.DUPLICATE_VARIABLE, defaultIndent, otherSeverities, otherSeverityLabels);
+		addComboBox(generalProblems, "include using variable", IssueCodes.VARIABLE_INCLUDE, defaultIndent, otherSeverities, otherSeverityLabels);
 
 		Composite linkingProblems = createSection("Linking", composite, nColumns);
-		addComboBox(linkingProblems, "absolute include", IssueCodes.ABSOLUTE_INCLUDE, defaultIndent, otherErrors, otherErrorLabels);
-		addComboBox(linkingProblems, "unresolvable include (.ly)", IssueCodes.UNRESOLVABLE_INCLUDE_STANDALONE, defaultIndent, otherErrors, otherErrorLabels);
-		addComboBox(linkingProblems, "unresolvable include (.ily...)", IssueCodes.UNRESOLVABLE_INCLUDE_ILY, defaultIndent, otherErrors, otherErrorLabels);
-		addComboBox(linkingProblems, "unknown variable (.ly)", IssueCodes.UNKNOWN_VARIABLE_STANDALONE, defaultIndent, linkingErrors, linkingErrorLabels);
-		addComboBox(linkingProblems, "unknown variable (.ily...)", IssueCodes.UNKNOWN_VARIABLE_ILY, defaultIndent, linkingErrors, linkingErrorLabels);
+		addComboBox(linkingProblems, "absolute include", IssueCodes.ABSOLUTE_INCLUDE, defaultIndent, otherSeverities, otherSeverityLabels);
+		addComboBox(linkingProblems, "unresolvable include (.ly)", IssueCodes.UNRESOLVABLE_INCLUDE_STANDALONE, defaultIndent, otherSeverities, otherSeverityLabels);
+		addComboBox(linkingProblems, "unresolvable include (.ily...)", IssueCodes.UNRESOLVABLE_INCLUDE_ILY, defaultIndent, otherSeverities, otherSeverityLabels);
+		addComboBox(linkingProblems, "unknown variable (.ly)", IssueCodes.UNKNOWN_VARIABLE_STANDALONE, defaultIndent, linkingSeverities, linkingSeverityLabels);
+		addComboBox(linkingProblems, "unknown variable (.ily...)", IssueCodes.UNKNOWN_VARIABLE_ILY, defaultIndent, linkingSeverities, linkingSeverityLabels);
 		noLinkingErrorAssignments=new LilyPondListEditor();
 		noLinkingErrorAssignments.setPreferenceStore(preferenceStore);
 		noLinkingErrorAssignments.setPreferenceName(IssueCodes.UNKNOWN_VARIABLE_IGNORES);

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/preferences/LilyPondValidatorConfigBlock.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/preferences/LilyPondValidatorConfigBlock.java
@@ -25,6 +25,9 @@ import org.elysium.validation.IssueCodes;
 @SuppressWarnings("restriction")
 public class LilyPondValidatorConfigBlock extends AbstractValidatorConfigurationBlock {
 
+	private static final String[] linkingErrors=new String[]{"ignore","warning","error"};
+	private static final String[] linkingErrorLabels=new String[]{"Ignore","Warning","Error"};
+
 	private static final String[] otherErrors=new String[]{"ignore","info","warning","error"};
 	private static final String[] otherErrorLabels=new String[]{"Ignore","Info","Warning","Error"};
 
@@ -46,8 +49,8 @@ public class LilyPondValidatorConfigBlock extends AbstractValidatorConfiguration
 		Composite linkingProblems = createSection("Linking", composite, nColumns);
 		addComboBox(linkingProblems, "unresolvable include (.ly)", IssueCodes.UNRESOLVABLE_INCLUDE_STANDALONE, defaultIndent, otherErrors, otherErrorLabels);
 		addComboBox(linkingProblems, "unresolvable include (.ily...)", IssueCodes.UNRESOLVABLE_INCLUDE_ILY, defaultIndent, otherErrors, otherErrorLabels);
-		addComboBox(linkingProblems, "unknown variable (.ly)", IssueCodes.UNKNOWN_VARIABLE_STANDALONE, defaultIndent, otherErrors, otherErrorLabels);
-		addComboBox(linkingProblems, "unknown variable (.ily...)", IssueCodes.UNKNOWN_VARIABLE_ILY, defaultIndent, otherErrors, otherErrorLabels);
+		addComboBox(linkingProblems, "unknown variable (.ly)", IssueCodes.UNKNOWN_VARIABLE_STANDALONE, defaultIndent, linkingErrors, linkingErrorLabels);
+		addComboBox(linkingProblems, "unknown variable (.ily...)", IssueCodes.UNKNOWN_VARIABLE_ILY, defaultIndent, linkingErrors, linkingErrorLabels);
 		noLinkingErrorAssignments=new LilyPondListEditor();
 		noLinkingErrorAssignments.setPreferenceStore(preferenceStore);
 		noLinkingErrorAssignments.setPreferenceName(IssueCodes.UNKNOWN_VARIABLE_IGNORES);

--- a/org.elysium.parent/org.elysium/src/org/elysium/conversion/LilyPondStringValueConverter.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/conversion/LilyPondStringValueConverter.java
@@ -1,0 +1,25 @@
+package org.elysium.conversion;
+
+import org.eclipse.xtext.conversion.IValueConverter;
+import org.eclipse.xtext.conversion.ValueConverterException;
+import org.eclipse.xtext.nodemodel.INode;
+
+public class LilyPondStringValueConverter implements IValueConverter<String> {
+
+	@Override
+	public String toValue(String string, INode node) throws ValueConverterException {
+		if(string != null && string.length() > 1) {
+			return string.substring(1, string.length()-1).replace("\\\"", "\"");
+		}
+		return null;
+	}
+
+	@Override
+	public String toString(String value) throws ValueConverterException {
+		if(value != null) {
+			return "\""+value.replace("\"", "\\\"")+"\"";
+		}else{
+			return null;
+		}
+	}
+}

--- a/org.elysium.parent/org.elysium/src/org/elysium/conversion/LilyPondValueConverterService.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/conversion/LilyPondValueConverterService.java
@@ -11,6 +11,7 @@ import org.eclipse.xtext.nodemodel.INode;
  */
 public class LilyPondValueConverterService extends DefaultTerminalConverters {
 
+	private static final IValueConverter<String> STRING_VALUE_CONVERTER = new LilyPondStringValueConverter();
 	private static final IValueConverter<Integer> INT_VALUE_CONVERTER = new org.eclipse.xtext.conversion.impl.INTValueConverter() {
 
 		@Override
@@ -50,6 +51,11 @@ public class LilyPondValueConverterService extends DefaultTerminalConverters {
 	@ValueConverter(rule = "SchemeBooleanValue")
 	public IValueConverter<Boolean> BOOL() {
 		return BOOL_VALUE_CONVERTER;
+	}
+
+	@Override
+	public IValueConverter<String> STRING() {
+		return STRING_VALUE_CONVERTER;
 	}
 
 }

--- a/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
@@ -33,12 +33,7 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 	private ILilyPondPathProvider lilyPondPathProvider;
 
 	public static boolean isAbsolute(String uriString) {
-		try {
-			return new File(uriString).isAbsolute();
-		}catch(Exception e) {
-			//ignore for now, spaces in file names cause problems
-		}
-		return false;
+		return new File(uriString).isAbsolute();
 	}
 
 	@Override

--- a/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
@@ -35,7 +35,11 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 	public static boolean isAbsolute(String uriString) {
 		String normalized = normalizedUriString(uriString);
 		if(normalized != null) {
-			return URI.create(normalized).isAbsolute();
+			try {
+				return URI.create(normalized).isAbsolute();
+			}catch(Exception e) {
+				//ignore for now, spaces in file names cause problems
+			}
 		}
 		return false;
 	}

--- a/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
@@ -32,6 +32,22 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 	@Inject
 	private ILilyPondPathProvider lilyPondPathProvider;
 
+	public static boolean isAbsolute(String uriString) {
+		String normalized = normalizedUriString(uriString);
+		if(normalized != null) {
+			return URI.create(normalized).isAbsolute();
+		}
+		return false;
+	}
+
+	private static String normalizedUriString(String uriString) {
+		if(uriString != null) {
+			return uriString.replace('\\','/');
+		} else {
+			return uriString;
+		}
+	}
+
 	@Override
 	public String resolve(EObject object) {
 		String importUri = super.resolve(object);
@@ -46,7 +62,8 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 		return importUri;
 	}
 
-	public LilyPondImportUri resolve(org.eclipse.emf.common.util.URI resourceURI, String importUri){
+	public LilyPondImportUri resolve(org.eclipse.emf.common.util.URI resourceURI, String nonNormalizedimportUri){
+		String importUri=normalizedUriString(nonNormalizedimportUri);
 		List<URI> searchUris = Lists.newArrayList(transform(lilyPondPathProvider.getSearchPaths(), new Function<String, URI>() {
 			@Override
 			public URI apply(String path) {
@@ -76,7 +93,7 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 		LilyPondImportUri.Type type=fromSearchPath?LilyPondImportUri.Type.searchPath:LilyPondImportUri.Type.relative;
 		boolean inWorkspace=true;
 		if(Platform.isRunning() && !uri.isRelative()){
-			if(URI.create(originalImportUri).isAbsolute()){
+			if(isAbsolute(originalImportUri)){
 				type=LilyPondImportUri.Type.absolute;
 			}
 			String platformString = Platform.getLocation().toString();

--- a/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
@@ -33,23 +33,12 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 	private ILilyPondPathProvider lilyPondPathProvider;
 
 	public static boolean isAbsolute(String uriString) {
-		String normalized = normalizedUriString(uriString);
-		if(normalized != null) {
-			try {
-				return URI.create(normalized).isAbsolute();
-			}catch(Exception e) {
-				//ignore for now, spaces in file names cause problems
-			}
+		try {
+			return new File(uriString).isAbsolute();
+		}catch(Exception e) {
+			//ignore for now, spaces in file names cause problems
 		}
 		return false;
-	}
-
-	private static String normalizedUriString(String uriString) {
-		if(uriString != null) {
-			return uriString.replace('\\','/');
-		} else {
-			return uriString;
-		}
 	}
 
 	@Override
@@ -66,8 +55,7 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 		return importUri;
 	}
 
-	public LilyPondImportUri resolve(org.eclipse.emf.common.util.URI resourceURI, String nonNormalizedimportUri){
-		String importUri=normalizedUriString(nonNormalizedimportUri);
+	public LilyPondImportUri resolve(org.eclipse.emf.common.util.URI resourceURI, String importUri){
 		List<URI> searchUris = Lists.newArrayList(transform(lilyPondPathProvider.getSearchPaths(), new Function<String, URI>() {
 			@Override
 			public URI apply(String path) {

--- a/org.elysium.parent/org.elysium/src/org/elysium/scoping/LilyPondImportUriGlobalScopeProvider.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/scoping/LilyPondImportUriGlobalScopeProvider.java
@@ -195,11 +195,7 @@ public class LilyPondImportUriGlobalScopeProvider extends AbstractGlobalScopePro
 	}
 
 	protected IScope createLazyResourceScope(IScope parent, final URI uri, final IResourceDescriptions descriptions, EClass type, final Predicate<IEObjectDescription> filter, boolean ignoreCase) {
-		try {
-			IResourceDescription description=getResourceDescriptionForUri(uri, descriptions);
-			return SelectableBasedScope.createScope(parent, description, filter, type, ignoreCase);
-		}catch(IllegalStateException e) {
-			return parent;
-		}
+		IResourceDescription description=getResourceDescriptionForUri(uri, descriptions);
+		return SelectableBasedScope.createScope(parent, description, filter, type, ignoreCase);
 	}
 }

--- a/org.elysium.parent/org.elysium/src/org/elysium/scoping/LilyPondImportUriGlobalScopeProvider.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/scoping/LilyPondImportUriGlobalScopeProvider.java
@@ -26,6 +26,7 @@ import org.eclipse.xtext.scoping.impl.ImportUriResolver;
 import org.eclipse.xtext.scoping.impl.LoadOnDemandResourceDescriptions;
 import org.eclipse.xtext.scoping.impl.SelectableBasedScope;
 import org.eclipse.xtext.util.IResourceScopeCache;
+import org.elysium.LilyPondConstants;
 import org.elysium.lilypond.Include;
 import org.elysium.lilypond.LilypondFactory;
 
@@ -81,9 +82,16 @@ public class LilyPondImportUriGlobalScopeProvider extends AbstractGlobalScopePro
 		Collections.reverse(urisAsList);
 		IScope scope = IScope.NULLSCOPE;
 		for (URI uri : urisAsList) {
-			scope = createLazyResourceScope(scope, uri, descriptions, type, filter, ignoreCase);
+			if(!ignoreImportUri(uri)) {
+				scope = createLazyResourceScope(scope, uri, descriptions, type, filter, ignoreCase);
+			}
 		}
 		return scope;
+	}
+
+	private boolean ignoreImportUri(URI uri) {
+		String extension = uri.fileExtension();
+		return !LilyPondConstants.EXTENSIONS.contains(extension);
 	}
 
 	private static final String[] DEFAULT_INCLUDES = {
@@ -187,7 +195,11 @@ public class LilyPondImportUriGlobalScopeProvider extends AbstractGlobalScopePro
 	}
 
 	protected IScope createLazyResourceScope(IScope parent, final URI uri, final IResourceDescriptions descriptions, EClass type, final Predicate<IEObjectDescription> filter, boolean ignoreCase) {
-		IResourceDescription description=getResourceDescriptionForUri(uri, descriptions);
-		return SelectableBasedScope.createScope(parent, description, filter, type, ignoreCase);
+		try {
+			IResourceDescription description=getResourceDescriptionForUri(uri, descriptions);
+			return SelectableBasedScope.createScope(parent, description, filter, type, ignoreCase);
+		}catch(IllegalStateException e) {
+			return parent;
+		}
 	}
 }

--- a/org.elysium.parent/org.elysium/src/org/elysium/validation/IssueCodes.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/validation/IssueCodes.java
@@ -27,6 +27,7 @@ public class IssueCodes extends ConfigurableIssueCodesProvider {
 	public static final String UNKNOWN_VARIABLE_STANDALONE = PREFIX + "UNKNOWN_VARIABLE_LY"; //$NON-NLS-1$
 	public static final String UNRESOLVABLE_INCLUDE_STANDALONE = PREFIX + "UNRESOLVABLE_INCLUDE_LY"; //$NON-NLS-1$
 	public static final String UNRESOLVABLE_INCLUDE_ILY = PREFIX + "UNRESOLVABLE_INCLUDE_ILY"; //$NON-NLS-1$
+	public static final String ABSOLUTE_INCLUDE = PREFIX + "ABSOLUTE_INCLUDE"; //$NON-NLS-1$
 	public static final String DUPLICATE_VARIABLE = PREFIX
 			+ "DUPLICATE_VARIABLE"; //$NON-NLS-1$
 	public static final String VARIABLE_INCLUDE = PREFIX + "VARIABLE_INCLUDE"; //$NON-NLS-1$
@@ -48,6 +49,7 @@ public class IssueCodes extends ConfigurableIssueCodesProvider {
 				.put(create(VARIABLE_INCLUDE, Severity.INFO))
 				.put(create(UNRESOLVABLE_INCLUDE_STANDALONE, Severity.IGNORE))
 				.put(create(UNRESOLVABLE_INCLUDE_ILY, Severity.IGNORE))
+				.put(create(ABSOLUTE_INCLUDE, Severity.WARNING))
 				.build();
 	}
 

--- a/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
@@ -11,6 +11,7 @@ import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.scoping.impl.ImportUriResolver;
 import org.eclipse.xtext.validation.Check;
 import org.elysium.LilyPondConstants;
+import org.elysium.importuri.LilyPondImportUriResolver;
 import org.elysium.lilypond.Command;
 import org.elysium.lilypond.Expression;
 import org.elysium.lilypond.Include;
@@ -80,6 +81,9 @@ public class LilyPondValidator extends AbstractLilyPondValidator {
 			if (!EcoreUtil2.isValidUri(include, URI.createURI(resolved))) {
 				addIssue("Include could not be resolved", getCurrentObject(), LilypondPackage.Literals.INCLUDE__IMPORT_URI, unresolvableIncludeCode);
 			}
+		}
+		if(LilyPondImportUriResolver.isAbsolute(include.getImportURI()) && !isIgnored(IssueCodes.ABSOLUTE_INCLUDE)) {
+			addIssue("Include with absolute location", getCurrentObject(), LilypondPackage.Literals.INCLUDE__IMPORT_URI, IssueCodes.ABSOLUTE_INCLUDE);
 		}
 	}
 }

--- a/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
@@ -77,10 +77,12 @@ public class LilyPondValidator extends AbstractLilyPondValidator {
 
 		String unresolvableIncludeCode=LilyPondConstants.isStandalone(include)?IssueCodes.UNRESOLVABLE_INCLUDE_STANDALONE:IssueCodes.UNRESOLVABLE_INCLUDE_ILY;
 		if(include.getImportURI()!=null && !isIgnored(unresolvableIncludeCode)){
-			String resolved = importUriResolver.resolve(include);
-			if (!EcoreUtil2.isValidUri(include, URI.createURI(resolved))) {
+			URI resolved = URI.createURI(importUriResolver.resolve(include));
+			if (!EcoreUtil2.isValidUri(include, resolved)) {
 				addIssue("Include could not be resolved", getCurrentObject(), LilypondPackage.Literals.INCLUDE__IMPORT_URI, unresolvableIncludeCode);
-			}
+			}else if(!LilyPondConstants.EXTENSIONS.contains(resolved.fileExtension())){
+				warning("Include does not have a known file extension; this may cause unexpected linking errors", LilypondPackage.Literals.INCLUDE__IMPORT_URI);
+ 			}
 		}
 		if(LilyPondImportUriResolver.isAbsolute(include.getImportURI()) && !isIgnored(IssueCodes.ABSOLUTE_INCLUDE)) {
 			addIssue("Include with absolute location", getCurrentObject(), LilypondPackage.Literals.INCLUDE__IMPORT_URI, IssueCodes.ABSOLUTE_INCLUDE);


### PR DESCRIPTION
This PR addresses #133 warning about absolute includes, #124 removing the info level from linking problems (possibly causing an IllegalStateException) and #125 preventing exceptions when including a directory or file with unkown file extensions.

It is not a refactoring of the include mechanism itself, but a first step to a stable behaviour.