### PR TITLE
code completion for midi instruments

### DIFF
--- a/Elysium.setup
+++ b/Elysium.setup
@@ -185,6 +185,10 @@
             optional="true"/>
         <requirement
             name="de.itemis.xtext.antlr.sdk.feature.group"/>
+        <requirement
+            name="org.eclipse.pde.junit.runtime"/>
+        <requirement
+            name="org.eclipse.jdt.junit4.runtime"/>
         <repositoryList
             name="Oxygen">
           <repository

--- a/org.elysium.parent/org.elysium.ui.tests/src/org/elysium/ui/contentassist/LilyPondProposalProviderTest.xtend
+++ b/org.elysium.parent/org.elysium.ui.tests/src/org/elysium/ui/contentassist/LilyPondProposalProviderTest.xtend
@@ -1,0 +1,43 @@
+package org.elysium.ui.contentassist
+
+import com.google.inject.Injector
+import java.io.InputStream
+import javax.inject.Inject
+import javax.inject.Provider
+import org.eclipse.emf.common.util.URI
+import org.eclipse.xtext.junit4.InjectWith
+import org.eclipse.xtext.junit4.XtextRunner
+import org.eclipse.xtext.junit4.ui.ContentAssistProcessorTestBuilder
+import org.eclipse.xtext.junit4.util.ResourceLoadHelper
+import org.eclipse.xtext.resource.XtextResource
+import org.eclipse.xtext.resource.XtextResourceSet
+import org.elysium.ui.tests.LilyPondUiInjectorProvider
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(typeof(XtextRunner))
+@InjectWith(typeof(LilyPondUiInjectorProvider))
+class LilyPondProposalProviderTest implements ResourceLoadHelper {
+
+	@Inject Injector injector
+	@Inject Provider<XtextResourceSet> resourceSetProvider
+
+	@Test
+	def void testMidiInstrument() {
+		newBuilder
+		.append('''\score{\relative c{\set midiInstrument = #"''')
+		.appendSuffix('"') //the implementation currently requires the closing quotes, so the assignment is complete
+		.assertProposal('"violin"')
+	}
+
+	def protected ContentAssistProcessorTestBuilder newBuilder() throws Exception {
+		new ContentAssistProcessorTestBuilder(injector, this)
+	}
+
+	override getResourceFor(InputStream stream) {
+		val set = resourceSetProvider.get()
+		val result = set.createResource(URI::createURI("test.ly"))
+		result.load(stream, null)
+		result as XtextResource
+	}
+}

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/contentassist/LilyPondProposalProvider.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/contentassist/LilyPondProposalProvider.java
@@ -10,6 +10,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.util.ResourceUtils;
 import org.eclipse.xtext.Assignment;
+import org.eclipse.xtext.RuleCall;
 import org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext;
 import org.eclipse.xtext.ui.editor.contentassist.ICompletionProposalAcceptor;
 import org.elysium.LilyPondConstants;
@@ -67,6 +68,24 @@ public class LilyPondProposalProvider extends AbstractLilyPondProposalProvider {
 					acceptor.accept(createCompletionProposal(QUOTE+child+QUOTE, context));
 				}
 			}
+		}
+	}
+
+	@Override
+	public void complete_SchemeValue(EObject model, RuleCall ruleCall, ContentAssistContext context,
+			ICompletionProposalAcceptor acceptor) {
+		try {
+			EObject possibleAssignment = model.eContainer().eContainer();
+			if(possibleAssignment instanceof org.elysium.lilypond.Assignment) {
+				org.elysium.lilypond.Assignment assignemt = (org.elysium.lilypond.Assignment) possibleAssignment;
+				if("midiInstrument".equals(assignemt.getName())) {
+					for (String instrument : MidiInstruments.get()) {
+						acceptor.accept(createCompletionProposal(QUOTE+instrument+QUOTE, context));
+					}
+				}
+			}
+		}catch(Exception e) {
+			//ignore any problems
 		}
 	}
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/contentassist/MidiInstruments.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/contentassist/MidiInstruments.java
@@ -1,0 +1,33 @@
+package org.elysium.ui.contentassist;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+class MidiInstruments {
+
+	static List<String> get() {
+		return ImmutableList.of("acoustic grand", "contrabass", "lead 7 (fifths)", "bright acoustic", "tremolo strings",
+				"lead 8 (bass+lead)", "electric grand", "pizzicato strings", "pad 1 (new age)", "honky-tonk",
+				"orchestral harp", "pad 2 (warm)", "electric piano 1", "timpani", "pad 3 (polysynth)",
+				"electric piano 2", "string ensemble 1", "pad 4 (choir)", "harpsichord", "string ensemble 2",
+				"pad 5 (bowed)", "clav", "synthstrings 1", "pad 6 (metallic)", "celesta", "synthstrings 2",
+				"pad 7 (halo)", "glockenspiel", "choir aahs", "pad 8 (sweep)", "music box", "voice oohs", "fx 1 (rain)",
+				"vibraphone", "synth voice", "fx 2 (soundtrack)", "marimba", "orchestra hit", "fx 3 (crystal)",
+				"xylophone", "trumpet", "fx 4 (atmosphere)", "tubular bells", "trombone", "fx 5 (brightness)",
+				"dulcimer", "tuba", "fx 6 (goblins)", "drawbar organ", "muted trumpet", "fx 7 (echoes)",
+				"percussive organ", "french horn", "fx 8 (sci-fi)", "rock organ", "brass section", "sitar",
+				"church organ", "synthbrass 1", "banjo", "reed organ", "synthbrass 2", "shamisen", "accordion",
+				"soprano sax", "koto", "harmonica", "alto sax", "kalimba", "concertina", "tenor sax", "bagpipe",
+				"acoustic guitar (nylon)", "baritone sax", "fiddle", "acoustic guitar (steel)", "oboe", "shanai",
+				"electric guitar (jazz)", "english horn", "tinkle bell", "electric guitar (clean)", "bassoon", "agogo",
+				"2electric guitar (muted)", "clarinet", "steel drums", "overdriven guitar", "piccolo", "woodblock",
+				"distorted guitar", "flute", "taiko drum", "guitar harmonics", "recorder", "melodic tom",
+				"acoustic bass", "pan flute", "synth drum", "electric bass (finger)", "blown bottle", "reverse cymbal",
+				"electric bass (pick)", "shakuhachi", "guitar fret noise", "fretless bass", "whistle", "breath noise",
+				"slap bass 1", "ocarina", "seashore", "slap bass 2", "lead 1 (square)", "bird tweet", "synth bass 1",
+				"lead 2 (sawtooth)", "telephone ring", "synth bass 2", "lead 3 (calliope)", "helicopter", "violin",
+				"lead 4 (chiff)", "applause", "viola", "lead 5 (charang)", "gunshot", "cello", "lead 6 (voice)");
+	}
+
+}


### PR DESCRIPTION
This is a very simple code completion for the midi instruments listed at http://lilypond.org/doc/v2.19/Documentation/notation/midi-instruments

It fires within the quotation marks in an assignment like `\set midiInstrument =#"violin"`