### PR TITLE
Syntax updater

### DIFF
--- a/org.elysium.parent/org.elysium/src/org/elysium/LilyPondConstants.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/LilyPondConstants.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import org.eclipse.emf.ecore.EObject;
 
+import com.google.common.base.Optional;
+
 public interface LilyPondConstants {
 
 	/**
@@ -32,6 +34,8 @@ public interface LilyPondConstants {
 	String AUDIO_EXTENSION = "midi"; //$NON-NLS-1$
 
 	List<String> COMPILED_EXTENSIONS = Arrays.asList(SCORE_EXTENSION, AUDIO_EXTENSION);
+
+	boolean IS_WINDOWS = Optional.fromNullable(System.getProperty("os.name")).or("another").toLowerCase().contains("win");//$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
 
 	public static boolean isStandalone(EObject o){
 		return EXTENSION.equals(o.eResource().getURI().fileExtension());

--- a/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
@@ -13,6 +13,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.scoping.impl.ImportUriResolver;
+import org.elysium.LilyPondConstants;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -26,8 +27,6 @@ import com.google.inject.Inject;
  * Resolves importURIs by first searching in LilyPond's default include path.
  */
 public class LilyPondImportUriResolver extends ImportUriResolver {
-
-	private static final boolean IS_WINDOWS = Optional.fromNullable(System.getProperty("os.name")).or("another").toLowerCase().contains("win");//$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
 
 	@Inject
 	private ILilyPondPathProvider lilyPondPathProvider;
@@ -97,7 +96,7 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 
 	private URI saferResolve(URI base, String importUri){
 		URI resolvedImportUri = base.resolve(org.eclipse.emf.common.util.URI.encodeOpaquePart(importUri, true));
-		boolean needToHandleAbsoluteWindowsLocation=IS_WINDOWS && resolvedImportUri.getScheme()!=null && !"file".equals(resolvedImportUri.getScheme());//$NON-NLS-1$
+		boolean needToHandleAbsoluteWindowsLocation=LilyPondConstants.IS_WINDOWS && resolvedImportUri.getScheme()!=null && !"file".equals(resolvedImportUri.getScheme());//$NON-NLS-1$
 		if(needToHandleAbsoluteWindowsLocation){
 			return URI.create("file:/"+resolvedImportUri.toString());//$NON-NLS-1$
 		}else{


### PR DESCRIPTION
This PR addresses #128. The invocation of the converter needs to be done differently on windows, where .py files may not necessarily be treated as executable. The implemented way looks for a python-executable next to the LilyPond executable. If python did not come with LilyPond it is expected to be on the path. (A more elaborate version would ask for the python executable path).

With your permission, I would add two further modifications to this PR.
* I would invoke the syntax update only if Lilypond compilation is activated as well. To me it makes no sense to continuously run the syntax updater when editing and saving, if I don't want to compile as well.
* I would like to remove the redundant --edit parameter from SyntaxUpdaterProcessBuilderFactory.get, this parameter is set in CompilerJob anyway (whether the file is opened in an editor or not).