### PR TITLE
update syntax only when compile is active

### DIFF
--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
@@ -80,7 +80,7 @@ public class CompilerJob extends Job {
 			console.firePropertyChange(this, IConsoleConstants.P_CONSOLE_OUTPUT_COMPLETE, null, false);
 
 			long start = System.currentTimeMillis();
-			preprocess(monitor, console);
+			preprocess(monitor, console, fullCompile);
 
 			checkCancelled(monitor);
 			if (fullCompile){
@@ -155,12 +155,12 @@ public class CompilerJob extends Job {
 		environment.put("LANG", locale.toString()); //$NON-NLS-1$
 	}
 
-	private void preprocess(final IProgressMonitor monitor, final CompilerConsole console) {
+	private void preprocess(final IProgressMonitor monitor, final CompilerConsole console, boolean doCompile) {
 		checkCancelled(monitor);
 		monitor.subTask("updating syntax");
 		// Update syntax if enabled
 		boolean updateSyntax = Activator.getInstance().getPreferenceStore().getBoolean(SyntaxUpdaterPreferenceConstants.UPDATE_SYNTAX.name());
-		if (updateSyntax) {
+		if (doCompile && updateSyntax) {
 			final IEditorPart editor = EditorUtils.getEditorWithFile(file);
 			if (editor != null) {
 				// If the file is open then reopen it
@@ -206,6 +206,8 @@ public class CompilerJob extends Job {
 		try {
 			ProcessBuilder processBuilder = SyntaxUpdaterProcessBuilderFactory.get(file);
 			prepareProcessBuilder(processBuilder);
+			List<String> command = processBuilder.command();
+			command.add(command.size() - 1, "--edit"); //$NON-NLS-1$
 
 			OutputProcessor outputProcessor = new SyntaxUpdaterOutputProcessor(console);
 

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
@@ -206,8 +206,6 @@ public class CompilerJob extends Job {
 		try {
 			ProcessBuilder processBuilder = SyntaxUpdaterProcessBuilderFactory.get(file);
 			prepareProcessBuilder(processBuilder);
-			List<String> command = processBuilder.command();
-			command.add(command.size() - 1, "--edit"); //$NON-NLS-1$
 
 			OutputProcessor outputProcessor = new SyntaxUpdaterOutputProcessor(console);
 

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/updater/SyntaxUpdaterProcessBuilderFactory.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/updater/SyntaxUpdaterProcessBuilderFactory.java
@@ -32,6 +32,7 @@ public class SyntaxUpdaterProcessBuilderFactory {
 		}else{
 			command=createCommandBase(path);
 		}
+		command.add("--edit"); //$NON-NLS-1$
 
 		if (preferenceStore.getBoolean(SyntaxUpdaterPreferenceConstants.FORCE_CURRENT_VERSION.name())) {
 			command.add("--current-version"); //$NON-NLS-1$

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/updater/SyntaxUpdaterProcessBuilderFactory.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/updater/SyntaxUpdaterProcessBuilderFactory.java
@@ -7,8 +7,6 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.preference.IPreferenceStore;
-import org.eclipse.ui.IEditorPart;
-import org.eclipse.util.EditorUtils;
 import org.elysium.LilyPondConstants;
 import org.elysium.ui.Activator;
 import org.elysium.ui.compiler.preferences.CompilerPreferenceConstants;
@@ -33,10 +31,6 @@ public class SyntaxUpdaterProcessBuilderFactory {
 			command=createWindowsCommandBase(path);
 		}else{
 			command=createCommandBase(path);
-		}
-		IEditorPart editor = EditorUtils.getEditorWithFile(file);
-		if (editor == null) {
-			command.add("--edit"); //$NON-NLS-1$
 		}
 
 		if (preferenceStore.getBoolean(SyntaxUpdaterPreferenceConstants.FORCE_CURRENT_VERSION.name())) {


### PR DESCRIPTION
With your additional commit (after PR #145), you removed the duplicate edit parameter from CompilerJob. I'd remove it completely from SyntaxUpdaterProcessBuilderFactory, because there it is set only if no editor is open. However, the compiler closes the editor, anyway. So now, the editor would be closed and reopened even though the edit parameter is not set at all.

Also, I suggest invoking the syntax update only if compilation is active (see comment 1 in #145)
