### PR TITLE
rewrite include resolution

### DIFF
--- a/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/importuri/ImportUriResolverTest.java
+++ b/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/importuri/ImportUriResolverTest.java
@@ -1,50 +1,91 @@
 package org.elysium.tests.importuri;
 
+import java.net.URI;
+import java.util.List;
+
+import org.elysium.LilyPondConstants;
 import org.elysium.importuri.LilyPondImportUriResolver;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
-//TODO find a way to allow these tests to run system independent
 public class ImportUriResolverTest {
 
-	private boolean isWindows=Optional.fromNullable(System.getProperty("os.name")).or("another").toLowerCase().contains("win");//$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
-
 	@Test
-	public void testAbsolute() {
-		checkIsAbsolute(null, false);
-		checkIsAbsolute("", false);
-		checkIsAbsolute("file.ly", false);
-		checkIsAbsolute("fi le.ly", false);
-		checkIsAbsolute("folder/file.ly", false);
-		checkIsAbsolute("fol der/fi le.ly", false);
-		checkIsAbsolute("../file.ly", false);
-		checkIsAbsolute("../fi le.ly", false);
-		checkIsAbsolute("../otherFolder/file.ly", false);
-		checkIsAbsolute("../other Folder/fi le.ly", false);
-
-		
-		if(isWindows) {
-			checkIsAbsolute("c:/windowsfolder/file.ly", true);
-			checkIsAbsolute("c:/windows folder/fi le.ly", true);
-			checkIsAbsolute("c:\\windowsfolder\\file.ly", true);
-			checkIsAbsolute("c:\\windows folder\\fi le.ly", true);
-			checkIsAbsolute("c:\\\\windowsfolder\\\\file.ly", true);
-			checkIsAbsolute("c:\\\\windows folder\\\\fi le.ly", true);
-		}else {
-			checkIsAbsolute("/file.ly", true);
-			checkIsAbsolute("/fi le.ly", true);
-			checkIsAbsolute("/unixfolder/file.ly", true);
-			checkIsAbsolute("/unix folder/fi le.ly", true);
-			checkIsAbsolute("file:/file.ly", true);
-			checkIsAbsolute("file:/fi le.ly", true);
-			checkIsAbsolute("file:/unixfolder/file.ly", true);
-			checkIsAbsolute("file:/unix folder/fi le.ly", true);
+	public void testAbsoluteWindows() {
+		boolean isWindows=true;
+		assertNotAbsolute(isWindows);
+		if(LilyPondConstants.IS_WINDOWS) {
+			//on non-windows systems new File("c:/...") is not recognized as absolute
+			//hence this test is not platform independent
+			checkIsAbsolute("c:/windowsfolder/file.ly", true, isWindows);
+			checkIsAbsolute("c:/windows folder/fi le.ly", true, isWindows);
+			checkIsAbsolute("c:\\windowsfolder\\file.ly", true, isWindows);
+			checkIsAbsolute("c:\\windows folder\\fi le.ly", true, isWindows);
+			checkIsAbsolute("c:\\\\windowsfolder\\\\file.ly", true, isWindows);
+			checkIsAbsolute("c:\\\\windows folder\\\\fi le.ly", true, isWindows);
 		}
 	}
 
-	private void checkIsAbsolute(String includeString, boolean expectedAbsolute) {
-		Assert.assertEquals(expectedAbsolute, LilyPondImportUriResolver.isAbsolute(includeString));
+	@Test
+	public void testAbsoluteOther() {
+		boolean isWindows=false;
+		assertNotAbsolute(isWindows);
+		checkIsAbsolute("/file.ly", true, isWindows);
+		checkIsAbsolute("/fi le.ly", true, isWindows);
+		checkIsAbsolute("/unixfolder/file.ly", true, isWindows);
+		checkIsAbsolute("/unix folder/fi le.ly", true, isWindows);
+		checkIsAbsolute("file:/file.ly", true, isWindows);
+		checkIsAbsolute("file:/fi le.ly", true, isWindows);
+		checkIsAbsolute("file:/unixfolder/file.ly", true, isWindows);
+		checkIsAbsolute("file:/unix folder/fi le.ly", true, isWindows);
+		
+	}
+
+	private void assertNotAbsolute(boolean isWindows) {
+		checkIsAbsolute(null, false, isWindows);
+		checkIsAbsolute("", false, isWindows);
+		checkIsAbsolute("file.ly", false, isWindows);
+		checkIsAbsolute("fi le.ly", false, isWindows);
+		checkIsAbsolute("folder/file.ly", false, isWindows);
+		checkIsAbsolute("fol der/fi le.ly", false, isWindows);
+		checkIsAbsolute("../file.ly", false, isWindows);
+		checkIsAbsolute("../fi le.ly", false, isWindows);
+		checkIsAbsolute("../otherFolder/file.ly", false, isWindows);
+		checkIsAbsolute("../other Folder/fi le.ly", false, isWindows);
+	}
+
+	private void checkIsAbsolute(String includeString, boolean expectedAbsolute, boolean isWindows) {
+		Assert.assertEquals(expectedAbsolute, LilyPondImportUriResolver.isAbsolute(includeString, isWindows));
+	}
+
+	//TODO test resolve with file names including white spaces
+	@Test
+	public void safeResolveWithFileBase() {
+		List<String> bases= ImmutableList.of("file:/some/folder/","file:/some/folder/andfile.ly");
+		boolean isWindows=true;
+		for (String base : bases) {
+			//general
+			assertResolve(base, "file.ly", !isWindows, "file:/some/folder/file.ly");
+			assertResolve(base, "file.ly", isWindows, "file:/some/folder/file.ly");
+			assertResolve(base, "otherFolder/file.ly", !isWindows, "file:/some/folder/otherFolder/file.ly");
+			assertResolve(base, "otherFolder/file.ly", isWindows, "file:/some/folder/otherFolder/file.ly");
+			assertResolve(base, "../file.ly", !isWindows, "file:/some/file.ly");
+			assertResolve(base, "../file.ly", isWindows, "file:/some/file.ly");
+
+			//windows absolute
+			assertResolve(base, "C:/windowsFolder/file.ly", isWindows, "file:/C:/windowsFolder/file.ly");
+
+			//other absolute
+			assertResolve(base, "file:/unixFolder/file.ly", !isWindows, "file:/unixFolder/file.ly");
+			assertResolve(base, "/unixFolder/file.ly", !isWindows, "file:/unixFolder/file.ly");
+		}
+	}
+
+	private void assertResolve(String base, String include, boolean isWindows, String expectedResolved) {
+		URI baseURi = URI.create(base);
+		URI resolved = LilyPondImportUriResolver.saferResolve(baseURi, include, isWindows);
+		Assert.assertEquals(expectedResolved, resolved.toString());
 	}
 }

--- a/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/importuri/ImportUriResolverTest.java
+++ b/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/importuri/ImportUriResolverTest.java
@@ -13,6 +13,7 @@ public class ImportUriResolverTest {
 
 	@Test
 	public void testAbsolute() {
+		checkIsAbsolute(null, false);
 		checkIsAbsolute("", false);
 		checkIsAbsolute("file.ly", false);
 		checkIsAbsolute("fi le.ly", false);
@@ -36,6 +37,10 @@ public class ImportUriResolverTest {
 			checkIsAbsolute("/fi le.ly", true);
 			checkIsAbsolute("/unixfolder/file.ly", true);
 			checkIsAbsolute("/unix folder/fi le.ly", true);
+			checkIsAbsolute("file:/file.ly", true);
+			checkIsAbsolute("file:/fi le.ly", true);
+			checkIsAbsolute("file:/unixfolder/file.ly", true);
+			checkIsAbsolute("file:/unix folder/fi le.ly", true);
 		}
 	}
 

--- a/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/importuri/ImportUriResolverTest.java
+++ b/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/importuri/ImportUriResolverTest.java
@@ -60,7 +60,6 @@ public class ImportUriResolverTest {
 		Assert.assertEquals(expectedAbsolute, LilyPondImportUriResolver.isAbsolute(includeString, isWindows));
 	}
 
-	//TODO test resolve with file names including white spaces
 	@Test
 	public void safeResolveWithFileBase() {
 		List<String> bases= ImmutableList.of("file:/some/folder/","file:/some/folder/andfile.ly");
@@ -73,13 +72,20 @@ public class ImportUriResolverTest {
 			assertResolve(base, "otherFolder/file.ly", isWindows, "file:/some/folder/otherFolder/file.ly");
 			assertResolve(base, "../file.ly", !isWindows, "file:/some/file.ly");
 			assertResolve(base, "../file.ly", isWindows, "file:/some/file.ly");
+			assertResolve(base, "../otherFolder/file.ly", !isWindows, "file:/some/otherFolder/file.ly");
+			assertResolve(base, "../otherFolder/file.ly", isWindows, "file:/some/otherFolder/file.ly");
+			assertResolve(base, "../other Folder/fi le.ly", !isWindows, "file:/some/other%20Folder/fi%20le.ly");
+			assertResolve(base, "../other Folder/fi le.ly", isWindows, "file:/some/other%20Folder/fi%20le.ly");
 
 			//windows absolute
 			assertResolve(base, "C:/windowsFolder/file.ly", isWindows, "file:/C:/windowsFolder/file.ly");
+			assertResolve(base, "C:/windows Folder/fi le.ly", isWindows, "file:/C:/windows%20Folder/fi%20le.ly");
 
 			//other absolute
 			assertResolve(base, "file:/unixFolder/file.ly", !isWindows, "file:/unixFolder/file.ly");
 			assertResolve(base, "/unixFolder/file.ly", !isWindows, "file:/unixFolder/file.ly");
+			assertResolve(base, "file:/unix Folder/fi le.ly", !isWindows, "file:/unix%20Folder/fi%20le.ly");
+			assertResolve(base, "/unix Folder/fi le.ly", !isWindows, "file:/unix%20Folder/fi%20le.ly");
 		}
 	}
 

--- a/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/regression/GrammarRegressions.xtend
+++ b/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/regression/GrammarRegressions.xtend
@@ -364,14 +364,15 @@ class GrammarRegressions {
 	@Test
 	def void assignmentIncluded() {
 		val filename = "target/1 foo.ly";
+		val file=new File(filename)
 		try{
 			Files.writeStringIntoFile(filename, "abc = #1");
 			'''
-				\include "«filename»"
+				\include "«file.absoluteFile.canonicalPath»"
 				\abc
 			'''.parseWithoutErrors
 		}finally{
-			new File(filename).delete();
+			file.delete();
 		}
 	}
 

--- a/org.elysium.parent/org.elysium.ui/plugin.xml
+++ b/org.elysium.parent/org.elysium.ui/plugin.xml
@@ -86,17 +86,17 @@
     <command id="org.elysium.ui.commands.RecompileSelected" name="Recompile" categoryId="org.elysium.ui.commandCategories.LilyPond"/>
   </extension>
   <extension point="org.eclipse.ui.handlers">
-    <handler class="org.elysium.ui.compiler.handlers.RecompileEditedHandler" commandId="org.elysium.ui.commands.RecompileEdited">
+    <handler class="org.elysium.ui.LilyPondExecutableExtensionFactory:org.elysium.ui.compiler.handlers.RecompileEditedHandler" commandId="org.elysium.ui.commands.RecompileEdited">
       <activeWhen>
         <reference definitionId="org.elysium.ui.definitions.EditorOpen"/>
       </activeWhen>
     </handler>
-	<handler class="org.elysium.ui.compiler.handlers.RecompileViewedHandler" commandId="org.elysium.ui.commands.RecompileViewed">
+	<handler class="org.elysium.ui.LilyPondExecutableExtensionFactory:org.elysium.ui.compiler.handlers.RecompileViewedHandler" commandId="org.elysium.ui.commands.RecompileViewed">
     <activeWhen>
        <test property="org.elysium.ui.score.ScoreViewVisible"/>
     </activeWhen>
     </handler>
-    <handler class="org.elysium.ui.compiler.handlers.RecompileSelectedHandler" commandId="org.elysium.ui.commands.RecompileSelected">
+    <handler class="org.elysium.ui.LilyPondExecutableExtensionFactory:org.elysium.ui.compiler.handlers.RecompileSelectedHandler" commandId="org.elysium.ui.commands.RecompileSelected">
       <activeWhen>
         <with variable="selection">
           <not>

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/Activator.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/Activator.java
@@ -20,8 +20,9 @@ public class Activator extends ElysiumActivator {
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
 		instance = this;
+		OutdatedMarkerAdder outdatedMarkerAdder = getInjector(ORG_ELYSIUM_LILYPOND).getInstance(OutdatedMarkerAdder.class);
 		// Register resource change listeners
-		ResourcesPlugin.getWorkspace().addResourceChangeListener(new OutdatedMarkerAdder(), IResourceChangeEvent.POST_BUILD);
+		ResourcesPlugin.getWorkspace().addResourceChangeListener(outdatedMarkerAdder, IResourceChangeEvent.POST_BUILD);
 	}
 
 	/**

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondUiModule.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondUiModule.java
@@ -14,7 +14,6 @@ import org.eclipse.xtext.ui.editor.XtextEditor;
 import org.eclipse.xtext.ui.editor.autoedit.AbstractEditStrategyProvider;
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper;
 import org.eclipse.xtext.ui.editor.model.IResourceForEditorInputFactory;
-import org.eclipse.xtext.ui.editor.model.ResourceForIEditorInputFactory;
 import org.eclipse.xtext.ui.editor.outline.actions.IOutlineContribution;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreInitializer;
 import org.eclipse.xtext.ui.editor.quickfix.ISimilarityMatcher;
@@ -27,6 +26,7 @@ import org.elysium.importuri.ILilyPondPathProvider;
 import org.elysium.ui.autoedit.LilyPondAutoEditStrategyProvider;
 import org.elysium.ui.hyperlinks.LilyPondHyperlinkHelper;
 import org.elysium.ui.hyperlinks.LilyPondLanguageSpecificURIEditorOpener;
+import org.elysium.ui.hyperlinks.LilyPondResourceForIEditorInputFactory;
 import org.elysium.ui.outline.FilterIncludesOutlineContribution;
 import org.elysium.ui.preferences.LilyPondPreferenceInitializer;
 import org.elysium.ui.preferences.LilyPondValidatorConfigBlock;
@@ -91,7 +91,7 @@ public class LilyPondUiModule extends AbstractLilyPondUiModule {
 
 	@Override
 	public Class<? extends IResourceForEditorInputFactory> bindIResourceForEditorInputFactory() {
-		return ResourceForIEditorInputFactory.class;
+		return LilyPondResourceForIEditorInputFactory.class;
 	}
 
 	@Override

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
@@ -169,6 +169,7 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 				if (eObject instanceof Include) {
 					Include include = (Include)eObject;
 					if(include.getImportURI() != null){
+						//TODO use importUriResolver here!!
 						Resource includedEResource = EcoreUtil2.getResource(eResource, include.getImportURI());
 						if (includedEResource != null) {
 							IResource includedResource = ResourceUtils.convertEResourceToPlatformResource(includedEResource);

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
@@ -17,8 +17,10 @@ import javax.inject.Inject;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.common.util.URI;
@@ -31,6 +33,7 @@ import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.builder.IXtextBuilderParticipant;
 import org.eclipse.xtext.resource.IResourceDescription.Delta;
+import org.eclipse.xtext.scoping.impl.ImportUriResolver;
 import org.elysium.LilyPondConstants;
 import org.elysium.lilypond.Include;
 import org.elysium.ui.Activator;
@@ -44,6 +47,8 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 	private static final AtomicLong jobCount=new AtomicLong(0);
 	@Inject
 	private IPreferenceStore preferences;
+	@Inject
+	private ImportUriResolver importResolver;
 
 	@Override
 	public void build(final IBuildContext context, IProgressMonitor monitor) throws CoreException {
@@ -73,11 +78,11 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 		removeOutdatedMarkers(filesMarkedAsOutdated, rs);
 	}
 
-	public static void compile(Set<IFile> files) {
+	public void compile(Set<IFile> files) {
 		compile(files, new ResourceSetImpl(), true, true);
 	}
 
-	private static void compile(Set<IFile> files, ResourceSet resourceSetToUse, boolean executeLilyPondCompilation, boolean deleteMarkers) {
+	private void compile(Set<IFile> files, ResourceSet resourceSetToUse, boolean executeLilyPondCompilation, boolean deleteMarkers) {
 		int maxParallelCalls = Activator.getInstance().getPreferenceStore().getInt(CompilerPreferenceConstants.PARALLEL_COMPILES.name());
 		addAllIncludingFiles(files,resourceSetToUse);
 		List<IFile> sortedFiles=new ArrayList<IFile>(files);
@@ -100,7 +105,7 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 		}
 	}
 
-	private static void removeOutdatedMarkers(final Set<IFile> files, ResourceSet resourceSetToUse) throws CoreException {
+	private void removeOutdatedMarkers(final Set<IFile> files, ResourceSet resourceSetToUse) throws CoreException {
 		addAllIncludingFiles(files, resourceSetToUse);
 		for (IFile file : files) {
 			removeOutdatedMarker(file);
@@ -112,15 +117,17 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 	 * Adds all files in the workspace to the given list of files which (even
 	 * indirectly) include any file in the list.
 	 */
-	public static void addAllIncludingFiles(Set<IFile> files) {
+	public void addAllIncludingFiles(Set<IFile> files) {
 		addAllIncludingFiles(files, new ResourceSetImpl());
 	}
 
-	private static void addAllIncludingFiles(Set<IFile> files, ResourceSet resourceSetToUse) {
+	private void addAllIncludingFiles(Set<IFile> files, ResourceSet resourceSetToUse) {
 		Set<IProject> projects = new HashSet<IProject>();
 		for (IFile file : files) {
 			projects.add(file.getProject());
 		}
+		//TODO the project reference is not sufficient,
+		//it may not be set even if there is an include relation
 		for (IProject project : projects) {
 			projects.addAll(Arrays.asList(project.getReferencingProjects()));
 		}
@@ -136,7 +143,7 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 	 * Adds the given file to the list of files to build if it (even indirectly)
 	 * includes any of the files to build.
 	 */
-	private static void addIfNecessary(IFile file, Set<IFile> filesToBuild, Set<IFile> directIncludesAlreadyCalculated, ResourceSet resourceSetToUse) {
+	private void addIfNecessary(IFile file, Set<IFile> filesToBuild, Set<IFile> directIncludesAlreadyCalculated, ResourceSet resourceSetToUse) {
 		if (!filesToBuild.contains(file) && LilyPondConstants.EXTENSIONS.contains(file.getFileExtension())) {
 			if(directIncludesAlreadyCalculated.contains(file)){
 				return;
@@ -161,7 +168,7 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 	/**
 	 * Returns the files directly included in the given file.
 	 */
-	private static Set<IFile> getIncludedFiles(IFile file, ResourceSet resourceSetToUse) {
+	private Set<IFile> getIncludedFiles(IFile file, ResourceSet resourceSetToUse) {
 		Set<IFile> result = new HashSet<IFile>();
 		Resource eResource = resourceSetToUse.getResource(org.eclipse.emf.common.util.URI.createPlatformResourceURI(file.getFullPath().toString(), true), true);
 		if (eResource != null) {
@@ -169,13 +176,13 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 				if (eObject instanceof Include) {
 					Include include = (Include)eObject;
 					if(include.getImportURI() != null){
-						//TODO use importUriResolver here!!
-						Resource includedEResource = EcoreUtil2.getResource(eResource, include.getImportURI());
-						if (includedEResource != null) {
-							IResource includedResource = ResourceUtils.convertEResourceToPlatformResource(includedEResource);
-							if ((includedResource != null) && (includedResource instanceof IFile)) {
-								IFile includedFile = (IFile)includedResource;
-								result.add(includedFile);
+						String resolved = importResolver.resolve(include);
+						URI uri = URI.createURI(resolved);
+						if(uri.isFile()) {
+							Path path = new Path(uri.toFileString());
+							IFile inclFile = ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(path);
+							if(inclFile!=null && inclFile.exists()) {
+								result.add(inclFile);
 							}
 						}
 					}

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/handlers/RecompileEditedHandler.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/handlers/RecompileEditedHandler.java
@@ -1,20 +1,27 @@
 package org.elysium.ui.compiler.handlers;
 
+import javax.inject.Inject;
+import javax.inject.Provider;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.util.EditorUtils;
 import org.elysium.ui.compiler.LilyPondBuilder;
+
 import com.google.common.collect.Sets;
 
 public class RecompileEditedHandler extends AbstractHandler {
 
+	@Inject
+	private Provider<LilyPondBuilder> builder;
+	
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		IFile currentlyOpenFile = EditorUtils.getCurrentlyOpenFile();
 		if (currentlyOpenFile != null) {
-			LilyPondBuilder.compile(Sets.newHashSet(currentlyOpenFile));
+			builder.get().compile(Sets.newHashSet(currentlyOpenFile));
 		}
 		return null;
 	}

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/handlers/RecompileSelectedHandler.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/handlers/RecompileSelectedHandler.java
@@ -3,6 +3,9 @@ package org.elysium.ui.compiler.handlers;
 import java.util.HashSet;
 import java.util.Set;
 
+import javax.inject.Inject;
+import javax.inject.Provider;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -18,6 +21,9 @@ import org.elysium.LilyPondConstants;
 import org.elysium.ui.compiler.LilyPondBuilder;
 
 public class RecompileSelectedHandler extends AbstractHandler {
+
+	@Inject
+	private Provider<LilyPondBuilder> builder;
 
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
@@ -46,7 +52,7 @@ public class RecompileSelectedHandler extends AbstractHandler {
 				files.add(file);	
 			}
 		}
-		LilyPondBuilder.compile(files);
+		builder.get().compile(files);
 		return null;
 	}
 

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/handlers/RecompileViewedHandler.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/handlers/RecompileViewedHandler.java
@@ -1,5 +1,8 @@
 package org.elysium.ui.compiler.handlers;
 
+import javax.inject.Inject;
+import javax.inject.Provider;
+
 import org.eclipse.core.commands.AbstractHandler;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
@@ -13,12 +16,15 @@ import com.google.common.collect.ImmutableSet;
 
 public class RecompileViewedHandler extends AbstractHandler {
 
+	@Inject
+	private Provider<LilyPondBuilder> builder;
+
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
 		IFile scoreFile = ScoreViewType.getScoreFile();
 		if (scoreFile != null) {
 			IFile sourceFile = ResourceUtils.replaceExtension(scoreFile, LilyPondConstants.EXTENSION);
-			LilyPondBuilder.compile(ImmutableSet.of(sourceFile));
+			builder.get().compile(ImmutableSet.of(sourceFile));
 		}
 		return null;
 	}

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/outdated/OutdatedMarkerAdder.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/outdated/OutdatedMarkerAdder.java
@@ -4,11 +4,13 @@ import static org.eclipse.core.resources.IMarker.MESSAGE;
 import static org.eclipse.core.resources.IResource.DEPTH_ZERO;
 import static org.eclipse.core.resources.IResourceDelta.CHANGED;
 import static org.eclipse.core.resources.IResourceDelta.CONTENT;
-import static org.elysium.ui.compiler.LilyPondBuilder.addAllIncludingFiles;
 import static org.elysium.ui.markers.MarkerTypes.OUTDATED;
 import static org.elysium.ui.markers.MarkerTypes.UP_TO_DATE;
 import java.util.HashSet;
 import java.util.Set;
+
+import javax.inject.Inject;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
@@ -19,13 +21,17 @@ import org.eclipse.core.resources.IResourceDeltaVisitor;
 import org.eclipse.core.runtime.CoreException;
 import org.elysium.LilyPondConstants;
 import org.elysium.ui.Activator;
+import org.elysium.ui.compiler.LilyPondBuilder;
 
 /**
  * Adds outdated markers to LilyPond files when their contents changed.
  */
 public class OutdatedMarkerAdder implements IResourceChangeListener {
 
-	private static final IResourceDeltaVisitor VISITOR = new IResourceDeltaVisitor() {
+	@Inject
+	private LilyPondBuilder builder;
+
+	private final IResourceDeltaVisitor VISITOR = new IResourceDeltaVisitor() {
 
 		@Override
 		public boolean visit(IResourceDelta delta) throws CoreException {
@@ -35,7 +41,7 @@ public class OutdatedMarkerAdder implements IResourceChangeListener {
 				if ((delta.getFlags() & CONTENT) != 0) {
 					Set<IFile> files = new HashSet<IFile>();
 					files.add((IFile)resource);
-					addAllIncludingFiles(files);
+					builder.addAllIncludingFiles(files);
 					for (IFile file : files) {
 						if (file.findMarkers(UP_TO_DATE, false, DEPTH_ZERO).length != 0) {
 							// The builder signals non-semantic change with this marker

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondHyperlinkHelper.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondHyperlinkHelper.java
@@ -69,17 +69,6 @@ public class LilyPondHyperlinkHelper extends HyperlinkHelper {
 				if(uriToOpen.isFile() && !new File(uriToOpen.toFileString()).exists()) {
 					uriToOpen=null;
 				}
-//TODO remove: there should be only absolute URIs and relative URIs should not be resolved against current resource URI 
-//				if(!uriToOpen.isFile() || uriToOpen.isRelative()){
-//					uriToOpen=null;
-//					Resource includedEResource=EcoreUtil2.getResource(xtextResource, includeUri);
-//					if(includedEResource!=null){
-//						IResource includedResource = ResourceUtils.convertEResourceToPlatformResource(includedEResource);
-//						if (includedResource != null) {
-//							uriToOpen = includedEResource.getURI();
-//						}
-//					}
-//				}
 				if(uriToOpen!=null){
 					int linkOffset = nodeOffset + 1; // Ignore the surrounding quotation marks
 					int linkLength = nodeLength - 2;

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondHyperlinkHelper.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondHyperlinkHelper.java
@@ -1,5 +1,6 @@
 package org.elysium.ui.hyperlinks;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -8,7 +9,6 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.util.ResourceUtils;
 import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
@@ -21,7 +21,6 @@ import org.eclipse.ui.views.pdf.PdfViewPage;
 import org.eclipse.ui.views.pdf.PdfViewType;
 import org.eclipse.util.DocumentUtils;
 import org.eclipse.util.UiUtils;
-import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.nodemodel.ILeafNode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.XtextResource;
@@ -67,16 +66,20 @@ public class LilyPondHyperlinkHelper extends HyperlinkHelper {
 				Include include = (Include)object;
 				String includeUri=uriResolver.resolve(include);
 				URI uriToOpen=URI.createURI(includeUri);
-				if(!uriToOpen.isFile() || uriToOpen.isRelative()){
+				if(uriToOpen.isFile() && !new File(uriToOpen.toFileString()).exists()) {
 					uriToOpen=null;
-					Resource includedEResource=EcoreUtil2.getResource(xtextResource, includeUri);
-					if(includedEResource!=null){
-						IResource includedResource = ResourceUtils.convertEResourceToPlatformResource(includedEResource);
-						if (includedResource != null) {
-							uriToOpen = includedEResource.getURI();
-						}
-					}
 				}
+//TODO remove: there should be only absolute URIs and relative URIs should not be resolved against current resource URI 
+//				if(!uriToOpen.isFile() || uriToOpen.isRelative()){
+//					uriToOpen=null;
+//					Resource includedEResource=EcoreUtil2.getResource(xtextResource, includeUri);
+//					if(includedEResource!=null){
+//						IResource includedResource = ResourceUtils.convertEResourceToPlatformResource(includedEResource);
+//						if (includedResource != null) {
+//							uriToOpen = includedEResource.getURI();
+//						}
+//					}
+//				}
 				if(uriToOpen!=null){
 					int linkOffset = nodeOffset + 1; // Ignore the surrounding quotation marks
 					int linkLength = nodeLength - 2;

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondLanguageSpecificURIEditorOpener.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondLanguageSpecificURIEditorOpener.java
@@ -2,8 +2,11 @@ package org.elysium.ui.hyperlinks;
 
 import java.io.File;
 import java.text.MessageFormat;
+
 import org.apache.log4j.Logger;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IStorage;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.debug.core.sourcelookup.containers.LocalFileStorage;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
@@ -18,6 +21,7 @@ import org.eclipse.xtext.Constants;
 import org.eclipse.xtext.ui.editor.LanguageSpecificURIEditorOpener;
 import org.eclipse.xtext.ui.editor.XtextReadonlyEditorInput;
 import org.eclipse.xtext.ui.editor.utils.EditorUtils;
+
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
@@ -33,7 +37,18 @@ public class LilyPondLanguageSpecificURIEditorOpener extends LanguageSpecificURI
 	private String editorID;
 
 	@Override
-	public IEditorPart open(URI uri, EReference crossReference, int indexInList, boolean select) {
+	public IEditorPart open(URI origUri, EReference crossReference, int indexInList, boolean select) {
+		URI uri = origUri;
+		if(uri.isFile()) {
+			//if it is a file URI first try to find a workspace version of the file
+			IFile[] files = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(java.net.URI.create(uri.toString()));
+			for (IFile iFile : files) {
+				if(iFile.exists()) {
+					uri=URI.createPlatformResourceURI(iFile.getFullPath().toString(), true);
+				}
+			}
+		}
+
 		IEditorPart result = super.open(uri, crossReference, indexInList, select);
 		if (result == null && uri.isFile()) {
 			final String errorMessage = "Error while opening editor part for EMF URI ''{0}''";

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondLanguageSpecificURIEditorOpener.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondLanguageSpecificURIEditorOpener.java
@@ -39,12 +39,16 @@ public class LilyPondLanguageSpecificURIEditorOpener extends LanguageSpecificURI
 	@Override
 	public IEditorPart open(URI origUri, EReference crossReference, int indexInList, boolean select) {
 		URI uri = origUri;
+		String fragment = uri.fragment();
 		if(uri.isFile()) {
 			//if it is a file URI first try to find a workspace version of the file
 			IFile[] files = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(java.net.URI.create(uri.toString()));
 			for (IFile iFile : files) {
 				if(iFile.exists()) {
 					uri=URI.createPlatformResourceURI(iFile.getFullPath().toString(), true);
+					if(fragment!=null) {
+						uri=uri.appendFragment(fragment);
+					}
 				}
 			}
 		}

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondResourceForIEditorInputFactory.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondResourceForIEditorInputFactory.java
@@ -1,0 +1,48 @@
+package org.elysium.ui.hyperlinks;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IStorage;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.debug.core.sourcelookup.containers.LocalFileStorage;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.xtext.resource.IResourceFactory;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.ui.editor.model.ResourceForIEditorInputFactory;
+
+import com.google.inject.Inject;
+
+public class LilyPondResourceForIEditorInputFactory extends ResourceForIEditorInputFactory {
+
+	@Inject
+	private IResourceFactory resourceFactory;
+
+	@Override
+	protected Resource createResourceFor(IStorage storage) throws CoreException {
+		IStorage storageToUse=storage;
+		if(storageToUse instanceof IFile) {
+			//turn workspace file into local file with absolute location
+			IPath absoluteLocation = ((IFile)storageToUse).getLocation();
+			storageToUse=new LocalFileStorage(absoluteLocation.toFile());
+		}
+		if(storageToUse instanceof LocalFileStorage) {
+			//copy from super - file uri instead of platform uri
+			ResourceSet resourceSet = getResourceSet(storageToUse);
+			String absoluteLocation =  ((LocalFileStorage) storageToUse).getFile().getAbsolutePath();
+			URI uri=org.eclipse.emf.common.util.URI.createFileURI(absoluteLocation);
+			configureResourceSet(resourceSet, uri);
+			URI uriForResource = uri; 
+			if (!uri.isPlatform()) {
+				uriForResource = resourceSet.getURIConverter().normalize(uri);
+			}
+			XtextResource resource = (XtextResource) resourceFactory.createResource(uriForResource);
+			resourceSet.getResources().add(resource);
+			resource.setValidationDisabled(isValidationDisabled(uri, storageToUse));
+			return resource;
+		} else {
+			return super.createResourceFor(storageToUse);
+		}
+	}
+}

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoringInjects.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoringInjects.java
@@ -15,6 +15,7 @@ import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.elysium.LilyPondConstants;
 import org.elysium.importuri.ILilyPondPathProvider;
 import org.elysium.importuri.LilyPondImportUri;
+import org.elysium.importuri.LilyPondImportUri.Type;
 import org.elysium.importuri.LilyPondImportUriResolver;
 import org.elysium.ui.preferences.LilyPondRefactoringPreferencePage;
 
@@ -54,7 +55,11 @@ class LilyPondRefactoringInjects {
 	}
 
 	public LilyPondImportUri resolveImportUri(URI baseURI, String importUri) {
-		return uriResolver.resolve(baseURI, importUri);
+		String resolved=uriResolver.resolve(baseURI, importUri);
+		//TODO this is temporary, so that compile works
+		//LilyPondUri needs to be replaced
+		return new LilyPondImportUri(importUri, resolved, Type.relative, true);
+//		return uriResolver.resolve(baseURI, importUri);
 	}
 
 	public List<String> getSearchPaths() {

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoringInjects.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoringInjects.java
@@ -17,6 +17,7 @@ import org.elysium.importuri.ILilyPondPathProvider;
 import org.elysium.importuri.LilyPondImportUri;
 import org.elysium.importuri.LilyPondImportUri.Type;
 import org.elysium.importuri.LilyPondImportUriResolver;
+import org.elysium.importuri.LilyPondResolvedUri;
 import org.elysium.ui.preferences.LilyPondRefactoringPreferencePage;
 
 class LilyPondRefactoringInjects {
@@ -55,11 +56,10 @@ class LilyPondRefactoringInjects {
 	}
 
 	public LilyPondImportUri resolveImportUri(URI baseURI, String importUri) {
-		String resolved=uriResolver.resolve(baseURI, importUri);
+		LilyPondResolvedUri resolved=uriResolver.resolve(baseURI, importUri);
 		//TODO this is temporary, so that compile works
 		//LilyPondUri needs to be replaced
-		return new LilyPondImportUri(importUri, resolved, Type.relative, true);
-//		return uriResolver.resolve(baseURI, importUri);
+		return new LilyPondImportUri(importUri, resolved.get(), Type.relative, true);
 	}
 
 	public List<String> getSearchPaths() {

--- a/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
@@ -8,15 +8,15 @@ import java.net.URI;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.xtext.scoping.impl.ImportUriResolver;
 import org.elysium.LilyPondConstants;
 
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -28,6 +28,8 @@ import com.google.inject.Inject;
  * Resolves importURIs by first searching in LilyPond's default include path.
  */
 public class LilyPondImportUriResolver extends ImportUriResolver {
+
+	private static final String UNRESOLVED_URI_PREFIX = "really_did_not_find_include-";
 
 	@Inject
 	private ILilyPondPathProvider lilyPondPathProvider;
@@ -42,6 +44,10 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 		}
 	}
 
+	public static boolean isUnresolved(String resolvedUriString) {
+		return (!Strings.isNullOrEmpty(resolvedUriString) && resolvedUriString.startsWith(UNRESOLVED_URI_PREFIX));
+	}
+
 	@Override
 	public String resolve(EObject object) {
 		String importUri = super.resolve(object);
@@ -49,14 +55,24 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 			org.eclipse.emf.common.util.URI currentResourceURI=null;
 			if(object.eResource() != null){
 				currentResourceURI = object.eResource().getURI();
+				if(currentResourceURI.isPlatform() && Platform.isRunning()) {
+					//find absolute location of including file
+					String platformString = currentResourceURI.toPlatformString(true);
+					Path path = new Path(platformString);
+					IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(path);
+					if(file.exists()) {
+						IPath absoluteLocation = file.getLocation();
+						currentResourceURI=org.eclipse.emf.common.util.URI.createFileURI(absoluteLocation.toFile().getAbsolutePath());
+					}
+				}
 			}
-			LilyPondImportUri lilyPondUri = resolve(currentResourceURI, importUri);
-			return lilyPondUri.getUri();
+			String resolved = resolve(currentResourceURI, importUri);
+			return resolved;
 		}
 		return importUri;
 	}
 
-	public LilyPondImportUri resolve(org.eclipse.emf.common.util.URI resourceURI, String importUri){
+	public String resolve(org.eclipse.emf.common.util.URI resourceURI, String importUri){
 		List<URI> searchUris = Lists.newArrayList(transform(lilyPondPathProvider.getSearchPaths(), new Function<String, URI>() {
 			@Override
 			public URI apply(String path) {
@@ -66,42 +82,46 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 		String lilypondPath = lilyPondPathProvider.getLilyPondPath();
 		URI defaultSearchUri = getDefaultSearchUri(lilypondPath);
 		searchUris.add(defaultSearchUri);
+		if(resourceURI!=null) {
+			searchUris.add(URI.create(resourceURI.toString()));
+		}
 
 		for (URI searchUri : searchUris) {
 			URI resolvedImportUri = saferResolve(searchUri, importUri, LilyPondConstants.IS_WINDOWS);
-			File importedFile = new File(resolvedImportUri);
-			if (importedFile.exists()) {
-				//TODO fileNameCasing is a problem here
-				//TADA exists although file name is tada
-				return potentialPlatformURI(resourceURI, importUri, resolvedImportUri.toString(), true);
+			if(resolvedImportUri.isAbsolute()) {
+				File importedFile = new File(resolvedImportUri);
+				if (importedFile.exists()) {
+					return resolvedImportUri.toString();
+//				//TODO fileNameCasing is a problem here
+//				//TADA exists although file name is tada
+				}
 			}
 		}
-		//TODO instead of resourceURI in platform we need absolute file location
-		//TODO check whether search path or local file has precedence
-		return getFileUriOutsideWorkspace(resourceURI, importUri).or(potentialPlatformURI(resourceURI, importUri, importUri, false));
+		return UNRESOLVED_URI_PREFIX+importUri;
 	}
 
-	//turn absolute uris that are actually located within the workspace into platform URIS
-	private LilyPondImportUri potentialPlatformURI(org.eclipse.emf.common.util.URI resourceURI, String originalImportUri, String resolvedUriString, boolean fromSearchPath){
-		String uriString=resolvedUriString;
-		org.eclipse.emf.common.util.URI uri = org.eclipse.emf.common.util.URI.createURI(resolvedUriString);
-		LilyPondImportUri.Type type=fromSearchPath?LilyPondImportUri.Type.searchPath:LilyPondImportUri.Type.relative;
-		boolean inWorkspace=true;
-		if(Platform.isRunning() && !uri.isRelative()){
-			if(isAbsolute(originalImportUri, LilyPondConstants.IS_WINDOWS)){
-				type=LilyPondImportUri.Type.absolute;
-			}
-			String platformString = Platform.getLocation().toString();
-			int index = uriString.indexOf(platformString);
-			if(index>=0){
-				String relative = uriString.substring(index+platformString.length()+1);
-				uriString = org.eclipse.emf.common.util.URI.createPlatformResourceURI(relative, true).toString();
-			}else{
-				inWorkspace=false;
-			}
-		}
-		return new LilyPondImportUri(originalImportUri, uriString, type, inWorkspace);
-	}
+//TODO this may be code interesting for locating absolute file locations in Workspace
+//turn absolute uris that are actually located within the workspace into platform URIS
+//	private LilyPondImportUri potentialPlatformURI(org.eclipse.emf.common.util.URI resourceURI, String originalImportUri, String resolvedUriString, boolean fromSearchPath){
+//		String uriString=resolvedUriString;
+//		org.eclipse.emf.common.util.URI uri = org.eclipse.emf.common.util.URI.createURI(resolvedUriString);
+//		LilyPondImportUri.Type type=fromSearchPath?LilyPondImportUri.Type.searchPath:LilyPondImportUri.Type.relative;
+//		boolean inWorkspace=true;
+//		if(Platform.isRunning() && !uri.isRelative()){
+//			if(isAbsolute(originalImportUri, IS_WINDOWS)){
+//				type=LilyPondImportUri.Type.absolute;
+//			}
+//			String platformString = Platform.getLocation().toString();
+//			int index = uriString.indexOf(platformString);
+//			if(index>=0){
+//				String relative = uriString.substring(index+platformString.length()+1);
+//				uriString = org.eclipse.emf.common.util.URI.createPlatformResourceURI(relative, true).toString();
+//			}else{
+//				inWorkspace=false;
+//			}
+//		}
+//		return new LilyPondImportUri(originalImportUri, uriString, type, inWorkspace);
+//	}
 
 	public static URI saferResolve(URI base, String importUri, boolean isWindows) {
 		URI resolvedImportUri = base.resolve(org.eclipse.emf.common.util.URI.encodeOpaquePart(importUri, true));
@@ -110,34 +130,35 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 				return URI.create("file:/"+resolvedImportUri.toString());//$NON-NLS-1$
 			}
 		}else if(isAbsolute(importUri, isWindows)){
+			String importUriToUse=importUri;
 			if(importUri.startsWith("/")) {//$NON-NLS-1$
-				return URI.create("file:"+importUri);//$NON-NLS-1$
-			}else{
-				return URI.create(importUri);
+				importUriToUse="file:"+importUri;//$NON-NLS-1$
 			}
+			return URI.create(org.eclipse.emf.common.util.URI.encodeOpaquePart(importUriToUse, true));
 		}
 		return resolvedImportUri;
 	}
 
-	private Optional<LilyPondImportUri> getFileUriOutsideWorkspace(org.eclipse.emf.common.util.URI currentResourceUri, String importUri){
-		if(importUri.contains("..")){//$NON-NLS-1$
-			if(currentResourceUri!=null && currentResourceUri.isPlatform()){
-				File currentResourceAsFile = new File(Platform.getLocation()+currentResourceUri.toPlatformString(false));
-				if (currentResourceAsFile.exists()) {
-					URI resolvedImportUri = saferResolve(currentResourceAsFile.toURI(), importUri, LilyPondConstants.IS_WINDOWS);
-					IWorkspaceRoot workspaceRoot= ResourcesPlugin.getWorkspace().getRoot();
-					IFile[] importedFileFoundInWorkspace = workspaceRoot.findFilesForLocationURI(resolvedImportUri);
-					if(importedFileFoundInWorkspace.length==0){
-						File importedFile = new File(resolvedImportUri);
-						if (importedFile.exists()) {
-							return Optional.of(new LilyPondImportUri(importUri, resolvedImportUri.toString(), LilyPondImportUri.Type.relative, false));
-						}
-					}
-				}
-			}
-		}
-		return Optional.absent();
-	}
+//obsolete
+//	private Optional<LilyPondImportUri> getFileUriOutsideWorkspace(org.eclipse.emf.common.util.URI currentResourceUri, String importUri){
+//		if(importUri.contains("..")){//$NON-NLS-1$
+//			if(currentResourceUri!=null && currentResourceUri.isPlatform()){
+//				File currentResourceAsFile = new File(Platform.getLocation()+currentResourceUri.toPlatformString(false));
+//				if (currentResourceAsFile.exists()) {
+//					URI resolvedImportUri = saferResolve(currentResourceAsFile.toURI(), importUri, IS_WINDOWS);
+//					IWorkspaceRoot workspaceRoot= ResourcesPlugin.getWorkspace().getRoot();
+//					IFile[] importedFileFoundInWorkspace = workspaceRoot.findFilesForLocationURI(resolvedImportUri);
+//					if(importedFileFoundInWorkspace.length==0){
+//						File importedFile = new File(resolvedImportUri);
+//						if (importedFile.exists()) {
+//							return Optional.of(new LilyPondImportUri(importUri, resolvedImportUri.toString(), LilyPondImportUri.Type.relative, false));
+//						}
+//					}
+//				}
+//			}
+//		}
+//		return Optional.absent();
+//	}
 
 	public static URI getDefaultSearchUri(String lilypondPath) {
 		return defaultSearchUriCache.getUnchecked(lilypondPath);

--- a/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
@@ -17,6 +17,7 @@ import org.elysium.LilyPondConstants;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -32,7 +33,13 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 	private ILilyPondPathProvider lilyPondPathProvider;
 
 	public static boolean isAbsolute(String uriString) {
-		return new File(uriString).isAbsolute();
+		if(Strings.isNullOrEmpty(uriString)) {
+			return false;
+		}else if(IS_WINDOWS) {
+			return new File(uriString).isAbsolute();
+		} else {
+			return uriString.startsWith("/") || uriString.startsWith("file:/");//$NON-NLS-1$//$NON-NLS-2$
+		}
 	}
 
 	@Override

--- a/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUriResolver.java
@@ -92,36 +92,11 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 				File importedFile = new File(resolvedImportUri);
 				if (importedFile.exists()) {
 					return resolvedImportUri.toString();
-//				//TODO fileNameCasing is a problem here
-//				//TADA exists although file name is tada
 				}
 			}
 		}
 		return UNRESOLVED_URI_PREFIX+importUri;
 	}
-
-//TODO this may be code interesting for locating absolute file locations in Workspace
-//turn absolute uris that are actually located within the workspace into platform URIS
-//	private LilyPondImportUri potentialPlatformURI(org.eclipse.emf.common.util.URI resourceURI, String originalImportUri, String resolvedUriString, boolean fromSearchPath){
-//		String uriString=resolvedUriString;
-//		org.eclipse.emf.common.util.URI uri = org.eclipse.emf.common.util.URI.createURI(resolvedUriString);
-//		LilyPondImportUri.Type type=fromSearchPath?LilyPondImportUri.Type.searchPath:LilyPondImportUri.Type.relative;
-//		boolean inWorkspace=true;
-//		if(Platform.isRunning() && !uri.isRelative()){
-//			if(isAbsolute(originalImportUri, IS_WINDOWS)){
-//				type=LilyPondImportUri.Type.absolute;
-//			}
-//			String platformString = Platform.getLocation().toString();
-//			int index = uriString.indexOf(platformString);
-//			if(index>=0){
-//				String relative = uriString.substring(index+platformString.length()+1);
-//				uriString = org.eclipse.emf.common.util.URI.createPlatformResourceURI(relative, true).toString();
-//			}else{
-//				inWorkspace=false;
-//			}
-//		}
-//		return new LilyPondImportUri(originalImportUri, uriString, type, inWorkspace);
-//	}
 
 	public static URI saferResolve(URI base, String importUri, boolean isWindows) {
 		URI resolvedImportUri = base.resolve(org.eclipse.emf.common.util.URI.encodeOpaquePart(importUri, true));
@@ -138,27 +113,6 @@ public class LilyPondImportUriResolver extends ImportUriResolver {
 		}
 		return resolvedImportUri;
 	}
-
-//obsolete
-//	private Optional<LilyPondImportUri> getFileUriOutsideWorkspace(org.eclipse.emf.common.util.URI currentResourceUri, String importUri){
-//		if(importUri.contains("..")){//$NON-NLS-1$
-//			if(currentResourceUri!=null && currentResourceUri.isPlatform()){
-//				File currentResourceAsFile = new File(Platform.getLocation()+currentResourceUri.toPlatformString(false));
-//				if (currentResourceAsFile.exists()) {
-//					URI resolvedImportUri = saferResolve(currentResourceAsFile.toURI(), importUri, IS_WINDOWS);
-//					IWorkspaceRoot workspaceRoot= ResourcesPlugin.getWorkspace().getRoot();
-//					IFile[] importedFileFoundInWorkspace = workspaceRoot.findFilesForLocationURI(resolvedImportUri);
-//					if(importedFileFoundInWorkspace.length==0){
-//						File importedFile = new File(resolvedImportUri);
-//						if (importedFile.exists()) {
-//							return Optional.of(new LilyPondImportUri(importUri, resolvedImportUri.toString(), LilyPondImportUri.Type.relative, false));
-//						}
-//					}
-//				}
-//			}
-//		}
-//		return Optional.absent();
-//	}
 
 	public static URI getDefaultSearchUri(String lilypondPath) {
 		return defaultSearchUriCache.getUnchecked(lilypondPath);

--- a/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondResolvedUri.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondResolvedUri.java
@@ -1,0 +1,35 @@
+package org.elysium.importuri;
+
+//this class is provisional API
+public class LilyPondResolvedUri {
+
+	private String uri;
+	private boolean resolved;
+
+	private LilyPondResolvedUri(String uri, boolean resolved) {
+		if(uri==null && resolved) {
+			throw new IllegalStateException();
+		}
+		this.uri=uri;
+		this.resolved=resolved;
+	}
+
+	//this is intended to be used with existing file uris
+	//currently this is not yet enforced
+	public LilyPondResolvedUri(String resolvedFileUri) {
+		resolved=true;
+		uri=resolvedFileUri;
+	}
+
+	static LilyPondResolvedUri unresolved(String importUri) {
+		return new LilyPondResolvedUri(importUri, false);
+	}
+
+	public boolean isResolved() {
+		return resolved;
+	}
+
+	public String get() {
+		return uri;
+	}
+}

--- a/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
@@ -84,7 +84,7 @@ public class LilyPondValidator extends AbstractLilyPondValidator {
 				warning("Include does not have a known file extension; this may cause unexpected linking errors", LilypondPackage.Literals.INCLUDE__IMPORT_URI);
  			}
 		}
-		if(LilyPondImportUriResolver.isAbsolute(include.getImportURI()) && !isIgnored(IssueCodes.ABSOLUTE_INCLUDE)) {
+		if(LilyPondImportUriResolver.isAbsolute(include.getImportURI(), LilyPondConstants.IS_WINDOWS) && !isIgnored(IssueCodes.ABSOLUTE_INCLUDE)) {
 			addIssue("Include with absolute location", getCurrentObject(), LilypondPackage.Literals.INCLUDE__IMPORT_URI, IssueCodes.ABSOLUTE_INCLUDE);
 		}
 	}

--- a/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
@@ -7,10 +7,10 @@ import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.ILeafNode;
 import org.eclipse.xtext.nodemodel.INode;
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
-import org.eclipse.xtext.scoping.impl.ImportUriResolver;
 import org.eclipse.xtext.validation.Check;
 import org.elysium.LilyPondConstants;
 import org.elysium.importuri.LilyPondImportUriResolver;
+import org.elysium.importuri.LilyPondResolvedUri;
 import org.elysium.lilypond.Command;
 import org.elysium.lilypond.Expression;
 import org.elysium.lilypond.Include;
@@ -26,7 +26,7 @@ import com.google.inject.Inject;
 public class LilyPondValidator extends AbstractLilyPondValidator {
 
 	@Inject
-	private ImportUriResolver importUriResolver;
+	private LilyPondImportUriResolver importUriResolver;
 
 	public static Iterator<ILeafNode> getHiddenTokensAfterBackslash(Command object) {
 		ICompositeNode node = NodeModelUtils.getNode(object);
@@ -76,11 +76,11 @@ public class LilyPondValidator extends AbstractLilyPondValidator {
 
 		String unresolvableIncludeCode=LilyPondConstants.isStandalone(include)?IssueCodes.UNRESOLVABLE_INCLUDE_STANDALONE:IssueCodes.UNRESOLVABLE_INCLUDE_ILY;
 		if(include.getImportURI()!=null && !isIgnored(unresolvableIncludeCode)){
-			String resolvedUriString=importUriResolver.resolve(include);
-			if (LilyPondImportUriResolver.isUnresolved(resolvedUriString)) {
+			LilyPondResolvedUri resolvedUriString=importUriResolver.typedResolve(include);
+			if (!resolvedUriString.isResolved()) {
 				addIssue("Include could not be resolved", getCurrentObject(), LilypondPackage.Literals.INCLUDE__IMPORT_URI, unresolvableIncludeCode);
 			}else {
-				URI resolvedUri = URI.createURI(resolvedUriString);
+				URI resolvedUri = URI.createURI(resolvedUriString.get());
 				if(!LilyPondConstants.EXTENSIONS.contains(resolvedUri.fileExtension())){
 					warning("Include does not have a known file extension; this may cause unexpected linking errors", LilypondPackage.Literals.INCLUDE__IMPORT_URI);
 				}

--- a/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
@@ -3,7 +3,6 @@ package org.elysium.validation;
 import java.util.Iterator;
 
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.ILeafNode;
 import org.eclipse.xtext.nodemodel.INode;
@@ -77,12 +76,15 @@ public class LilyPondValidator extends AbstractLilyPondValidator {
 
 		String unresolvableIncludeCode=LilyPondConstants.isStandalone(include)?IssueCodes.UNRESOLVABLE_INCLUDE_STANDALONE:IssueCodes.UNRESOLVABLE_INCLUDE_ILY;
 		if(include.getImportURI()!=null && !isIgnored(unresolvableIncludeCode)){
-			URI resolved = URI.createURI(importUriResolver.resolve(include));
-			if (!EcoreUtil2.isValidUri(include, resolved)) {
+			String resolvedUriString=importUriResolver.resolve(include);
+			if (LilyPondImportUriResolver.isUnresolved(resolvedUriString)) {
 				addIssue("Include could not be resolved", getCurrentObject(), LilypondPackage.Literals.INCLUDE__IMPORT_URI, unresolvableIncludeCode);
-			}else if(!LilyPondConstants.EXTENSIONS.contains(resolved.fileExtension())){
-				warning("Include does not have a known file extension; this may cause unexpected linking errors", LilypondPackage.Literals.INCLUDE__IMPORT_URI);
- 			}
+			}else {
+				URI resolvedUri = URI.createURI(resolvedUriString);
+				if(!LilyPondConstants.EXTENSIONS.contains(resolvedUri.fileExtension())){
+					warning("Include does not have a known file extension; this may cause unexpected linking errors", LilypondPackage.Literals.INCLUDE__IMPORT_URI);
+				}
+			}	
 		}
 		if(LilyPondImportUriResolver.isAbsolute(include.getImportURI(), LilyPondConstants.IS_WINDOWS) && !isIgnored(IssueCodes.ABSOLUTE_INCLUDE)) {
 			addIssue("Include with absolute location", getCurrentObject(), LilypondPackage.Literals.INCLUDE__IMPORT_URI, IssueCodes.ABSOLUTE_INCLUDE);


### PR DESCRIPTION
This PR addresses #132 (and #146). When resolving includes, as far as possible the real file location is used as base for resolving the include. Within a running eclipse this should always work. More problematic are unit tests where no platform is running and URIs are synthetic.

LilyPondImportUriResolver no longer tries to resolve to a platform URI (i.e. a file located in the workspace) but rather to the absolute file location of the included file. The LilyPondLanguageSpecificURIEditorOpener tries to find a workspace version for such an absolute location and opens that if present - however with the absolute file URI for the openeed file (so find references works #146), otherwise a read-only version is opened as before.

The advantage of this approach should be that import resolution should be more in line with what LilyPond does, relative and absolute includes should also work on Mac/Linux now.

A naive attempt to ensure all base URIs are absolute failed. Trying to set the absolte file URI (rather than the platform URI of the underlying IFile processed during the Xtext build) in the XtextResourceFactory caused IllegalStateExceptions (URI already registered).

File Refactorings will be broken with this PR (LilyPondImportUri is not usable anymore). Fixing this is part of a different issue; as is using index information for determining files needing recompile.