### PR TITLE
marker logic

### DIFF
--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerJob.java
@@ -99,8 +99,8 @@ public class CompilerJob extends Job {
 			}
 			monitor.worked(1);
 
-			postprocess(monitor);
 			if(fullCompile){
+				postprocess(monitor);
 				long stop = System.currentTimeMillis();
 
 				float executionTimeInSeconds = (stop - start) / 1000f;

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/outdated/OutdatedMarkerAdder.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/outdated/OutdatedMarkerAdder.java
@@ -5,7 +5,7 @@ import static org.eclipse.core.resources.IResource.DEPTH_ZERO;
 import static org.eclipse.core.resources.IResourceDelta.CHANGED;
 import static org.eclipse.core.resources.IResourceDelta.CONTENT;
 import static org.elysium.ui.markers.MarkerTypes.OUTDATED;
-import static org.elysium.ui.markers.MarkerTypes.UP_TO_DATE;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -43,10 +43,7 @@ public class OutdatedMarkerAdder implements IResourceChangeListener {
 					files.add((IFile)resource);
 					builder.addAllIncludingFiles(files);
 					for (IFile file : files) {
-						if (file.findMarkers(UP_TO_DATE, false, DEPTH_ZERO).length != 0) {
-							// The builder signals non-semantic change with this marker
-							file.deleteMarkers(UP_TO_DATE, true, DEPTH_ZERO);
-						} else if (file.findMarkers(OUTDATED, false, DEPTH_ZERO).length == 0) {
+						if (file.findMarkers(OUTDATED, false, DEPTH_ZERO).length == 0) {
 							IMarker outdatedMarker = file.createMarker(OUTDATED);
 							outdatedMarker.setAttribute(MESSAGE, "This file has been changed since it was compiled");
 							// Refresh decorator

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/markers/MarkerTypes.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/markers/MarkerTypes.java
@@ -18,6 +18,4 @@ public class MarkerTypes {
 
 	public static final String OUTDATED = get("Outdated"); //$NON-NLS-1$
 
-	public static final String UP_TO_DATE = get("UpToDate"); //$NON-NLS-1$
-
 }


### PR DESCRIPTION
The PR addresses #148. The main modifications are that outdated-markers are removed only by the LilyPond compiler and that they are removed only if actual compilation took place.

Only if the compiler was really invoked can we be sure that the output is up to date. The UP_TO_DATE-marker logic seems obsolete.

I experimented with a modified recompile hash for indicating that a recompile is necessary - using a normalized text representation without hidden nodes (i.e. without white spaces or comments). The idea is, that the output will be the same if comments are added, spaces, i.e. no structural changes have taken place. The problem is that with those modifications the score hyperlinks are still affected. So if click-to-point generation is disabled the modified hash is OK, if it is enabled recompile is necessary to get the correct hyperlinks. Currently, I would not consider it worth making this distinction in the index information creation. If it is important to you, I can add it (let me know).