### PR TITLE
#154 add default compiler option for relative includes

### DIFF
--- a/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/Validator.java
+++ b/org.elysium.parent/org.elysium.tests/src/org/elysium/tests/Validator.java
@@ -3,11 +3,15 @@ package org.elysium.tests;
 import static com.google.common.base.Predicates.not;
 import static com.google.common.collect.Iterables.all;
 
+import org.eclipse.emf.common.util.Diagnostic;
 import org.eclipse.xtext.junit4.validation.AssertableDiagnostics;
+import org.eclipse.xtext.junit4.validation.ValidationTestHelper;
 import org.eclipse.xtext.junit4.validation.AssertableDiagnostics.DiagnosticPredicate;
 import org.eclipse.xtext.resource.XtextResource;
 import org.elysium.validation.IssueCodes;
 import org.junit.Test;
+
+import junit.framework.Assert;
 
 public class Validator extends LilyPondTest {
 
@@ -50,6 +54,16 @@ public class Validator extends LilyPondTest {
 	@Test
 	public void noVersion() throws Exception {
 		assertProblem("{}", IssueCodes.NO_VERSION_STANDALONE, false);
+	}
+
+	@Test
+	public void relativeIncludeOK() throws Exception {
+		validate("\\version \"2.18.0\" #(ly:set-option 'relative-includes #t)").assertOK();
+	}
+
+	@Test
+	public void relativeIncludeWarning() throws Exception {
+		validate("\\version \"2.18.0\" #(ly:set-option 'relative-includes #f)").assertWarning(0, "relative include");
 	}
 
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerProcessBuilderFactory.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerProcessBuilderFactory.java
@@ -35,6 +35,8 @@ public class CompilerProcessBuilderFactory {
 				command.add("--verbose"); //$NON-NLS-1$
 			}
 
+			command.add("-drelative-includes"); //$NON-NLS-1$
+
 			command.add(OptionBuilder.build("midi-extension", LilyPondConstants.AUDIO_EXTENSION)); //$NON-NLS-1$ // On Windows, the default extension is "mid"
 
 			for (String searchPath : UiLilyPondPathProvider.getTheSearchPaths()) {

--- a/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/validation/LilyPondValidator.java
@@ -2,6 +2,7 @@ package org.elysium.validation;
 
 import java.util.Iterator;
 
+import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.ILeafNode;
@@ -16,6 +17,8 @@ import org.elysium.lilypond.Expression;
 import org.elysium.lilypond.Include;
 import org.elysium.lilypond.LilyPond;
 import org.elysium.lilypond.LilypondPackage;
+import org.elysium.lilypond.SchemeExpression;
+import org.elysium.lilypond.SchemeList;
 import org.elysium.lilypond.Version;
 
 import com.google.inject.Inject;
@@ -90,4 +93,22 @@ public class LilyPondValidator extends AbstractLilyPondValidator {
 			addIssue("Include with absolute location", getCurrentObject(), LilypondPackage.Literals.INCLUDE__IMPORT_URI, IssueCodes.ABSOLUTE_INCLUDE);
 		}
 	}
+
+	@Check
+	public void checkSetRelativeInclude(SchemeList list) {
+		EList<SchemeExpression> expressions = list.getExpressions();
+		if(expressions.size()==3) {
+			if(textEquals(expressions.get(0), "ly:set-option")
+				&& textEquals(expressions.get(1), "'relative-includes")
+				&& !textEquals(expressions.get(2), "#t")) {
+				warning("Elysium supports only relative includes. Linking etc. may be broken", LilypondPackage.Literals.SCHEME_LIST__EXPRESSIONS, 2);
+			}
+		}
+	}
+
+	private boolean textEquals(SchemeExpression e, String text) {
+		String t = NodeModelUtils.getNode(e).getText();
+		return t!=null && text.equals(t.trim());
+	}
+
 }


### PR DESCRIPTION
I have added the compile option.
The second commit is a naive validation implementation - the semantic structure for schemes is too complex to do it in a nice way...