### PR TITLE
alternative OpenReadOnly

### DIFF
--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondUiModule.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondUiModule.java
@@ -16,6 +16,7 @@ import org.eclipse.xtext.ui.editor.autoedit.AbstractEditStrategyProvider;
 import org.eclipse.xtext.ui.editor.hover.IEObjectHoverProvider;
 import org.eclipse.xtext.ui.editor.hyperlinking.IHyperlinkHelper;
 import org.eclipse.xtext.ui.editor.model.IResourceForEditorInputFactory;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentProvider;
 import org.eclipse.xtext.ui.editor.outline.actions.IOutlineContribution;
 import org.eclipse.xtext.ui.editor.preferences.IPreferenceStoreInitializer;
 import org.eclipse.xtext.ui.editor.quickfix.ISimilarityMatcher;
@@ -126,5 +127,9 @@ public class LilyPondUiModule extends AbstractLilyPondUiModule {
 
 	public Class<? extends IEObjectHoverProvider> bindEObjectHoverProvider() {
 		return LilyPondEObjectHoverProvider.class;
+	}
+
+	public Class<? extends XtextDocumentProvider> bindDocumentProvider() {
+		return LilyPondXtextDocumentProvider.class;
 	}
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondXtextDocumentProvider.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondXtextDocumentProvider.java
@@ -1,0 +1,17 @@
+package org.elysium.ui;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ui.IURIEditorInput;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentProvider;
+
+public class LilyPondXtextDocumentProvider extends XtextDocumentProvider {
+
+	@Override
+	protected void updateCache(IURIEditorInput input) throws CoreException {
+		//prevent XtextDocumentProvider from turning read-only input to read-write input
+		URIInfo info= (URIInfo) getElementInfo(input);
+		if (info != null) {
+			info.updateCache= false;
+		}
+	}
+}

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondXtextEditor.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondXtextEditor.java
@@ -1,14 +1,9 @@
 package org.elysium.ui;
 
-import java.io.File;
-import java.net.URI;
-
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.debug.core.sourcelookup.containers.LocalFileStorage;
-import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.ide.FileStoreEditorInput;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.ui.IURIEditorInput;
 import org.eclipse.xtext.ui.editor.XtextEditor;
-import org.eclipse.xtext.ui.editor.XtextReadonlyEditorInput;
 
 import com.google.common.collect.ObjectArrays;
 
@@ -46,13 +41,20 @@ public class LilyPondXtextEditor extends XtextEditor{
 	}
 
 	@Override
-	protected void doSetInput(IEditorInput input) throws CoreException {
-		IEditorInput inputToSet=input;
-		if(inputToSet instanceof FileStoreEditorInput) {
-			//ensure that files outside the workspace cannot be modified
-			URI uri = ((FileStoreEditorInput) input).getURI();
-			inputToSet=new XtextReadonlyEditorInput(new LocalFileStorage(new File(uri)));
+	public String getTitleToolTip() {
+		String tooltip=super.getTitleToolTip();
+		IResource resource = getResource();
+		if(resource != null) {
+			return tooltip+ "\n"+ resource.getRawLocation().toString();
+		} else {
+			try {
+				IURIEditorInput input = ((IURIEditorInput) getEditorInput());
+				return input.getName()+"\n"+URI.createURI(input.getURI().toString()).toFileString().replace('\\', '/');
+			} catch (Exception e) {
+				//ignore
+			}
 		}
-		super.doSetInput(inputToSet);
+		return tooltip;
 	}
+
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondLanguageSpecificURIEditorOpener.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondLanguageSpecificURIEditorOpener.java
@@ -1,17 +1,13 @@
 package org.elysium.ui.hyperlinks;
 
-import java.io.File;
 import java.text.MessageFormat;
 
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.debug.core.sourcelookup.containers.LocalFileStorage;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.common.util.WrappedException;
 import org.eclipse.emf.ecore.EReference;
-import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPage;
@@ -19,7 +15,6 @@ import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.ide.IDE;
 import org.eclipse.xtext.Constants;
 import org.eclipse.xtext.ui.editor.LanguageSpecificURIEditorOpener;
-import org.eclipse.xtext.ui.editor.XtextReadonlyEditorInput;
 import org.eclipse.xtext.ui.editor.utils.EditorUtils;
 
 import com.google.inject.Inject;
@@ -57,10 +52,8 @@ public class LilyPondLanguageSpecificURIEditorOpener extends LanguageSpecificURI
 		if (result == null && uri.isFile()) {
 			final String errorMessage = "Error while opening editor part for EMF URI ''{0}''";
 			try {
-				IStorage storage = new LocalFileStorage(new File(uri.toFileString()));
-				IEditorInput editorInput = new XtextReadonlyEditorInput(storage);
 				IWorkbenchPage activePage = workbench.getActiveWorkbenchWindow().getActivePage();
-				IEditorPart editor = IDE.openEditor(activePage, editorInput, editorID);
+				IEditorPart editor = IDE.openEditor(activePage, java.net.URI.create(uri.toString()).normalize(), editorID, true);
 				selectAndReveal(editor, uri, crossReference, indexInList, select);
 				result = EditorUtils.getXtextEditor(editor);
 			} catch (WrappedException e) {


### PR DESCRIPTION
This is an alternative (and superior) approach to opening workspace external files read only. Currently, the editor input is wrapped as XtextReadonlyEditorInput. For score to source links this caused each link to be opened in a new editor.

The fix is extending XtextDocumentProvider which was responsible for enabling editing for orignially read-only inputs. In addition, the editor's title tooltip now shows name and location, so you can easily see where the opened file is located.