### PR TITLE
#146 fix find references within local file

### DIFF
--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondUiModule.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondUiModule.java
@@ -5,6 +5,7 @@ package org.elysium.ui;
 
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.eclipse.xtext.findReferences.TargetURICollector;
 import org.eclipse.xtext.ide.editor.syntaxcoloring.ISemanticHighlightingCalculator;
 import org.eclipse.xtext.resource.ILocationInFileProvider;
 import org.eclipse.xtext.resource.containers.IAllContainersState;
@@ -31,6 +32,7 @@ import org.elysium.ui.hyperlinks.LilyPondHyperlinkHelper;
 import org.elysium.ui.hyperlinks.LilyPondLanguageSpecificURIEditorOpener;
 import org.elysium.ui.hyperlinks.LilyPondLocationInFileProvider;
 import org.elysium.ui.hyperlinks.LilyPondResourceForIEditorInputFactory;
+import org.elysium.ui.hyperlinks.LilyPondTargetUriCollector;
 import org.elysium.ui.outline.FilterIncludesOutlineContribution;
 import org.elysium.ui.preferences.LilyPondPreferenceInitializer;
 import org.elysium.ui.preferences.LilyPondValidatorConfigBlock;
@@ -75,6 +77,10 @@ public class LilyPondUiModule extends AbstractLilyPondUiModule {
 	public void configureLanguageSpecificURIEditorOpener(Binder binder) {
 		if (PlatformUI.isWorkbenchRunning())
 			binder.bind(IURIEditorOpener.class).annotatedWith(LanguageSpecific.class).to(LilyPondLanguageSpecificURIEditorOpener.class);
+	}
+
+	public Class<? extends TargetURICollector> bindTargetURICollector() {
+		return LilyPondTargetUriCollector.class;
 	}
 
 	@Override

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondTargetUriCollector.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondTargetUriCollector.java
@@ -1,0 +1,37 @@
+package org.elysium.ui.hyperlinks;
+
+import java.util.Set;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.xtext.findReferences.TargetURICollector;
+import org.eclipse.xtext.findReferences.TargetURIs;
+
+public class LilyPondTargetUriCollector extends TargetURICollector {
+
+	@Override
+	protected void doAdd(EObject object, TargetURIs targetURIs) {
+		super.doAdd(object, targetURIs);
+		Set<URI> uris = targetURIs.asSet();
+		for (URI uri : uris) {
+			//if target URI is file uri, it may still be opened in an editor with platform uri
+			//so check if file exists in workspace and add as search URI
+			if(uri.isFile()) {
+				String fragment = uri.fragment();
+				//TODO similar findFilesForLocationURI for file URIS is now used in LilyPondProposalProvider, LilyPondHyperlinkHelper, LilyPondLanguageSpecificURIEditorOpener and here
+				IFile[] files = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(java.net.URI.create(uri.toString()));
+				for (IFile iFile : files) {
+					if(iFile.exists()) {
+						URI uriToAdd = URI.createPlatformResourceURI(iFile.getFullPath().toString(), true);
+						if(fragment!=null) {
+							uriToAdd=uriToAdd.appendFragment(fragment);
+						}
+						targetURIs.addURI(uriToAdd);
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Finding references within an opened file was broken. This is because the link target points to the file URI (absolute location), but the file is opened with platform URI. This fix adds a platform search target, if the file URI points to a workspace file.

This resolves #146.