### PR TITLE
File refactorings

### DIFF
--- a/org.elysium.parent/org.elysium.ui.tests/src/org/elysium/ui/refactoring/RefactoringIncludeHandlerTest.java
+++ b/org.elysium.parent/org.elysium.ui.tests/src/org/elysium/ui/refactoring/RefactoringIncludeHandlerTest.java
@@ -18,91 +18,112 @@ public class RefactoringIncludeHandlerTest {
 
 	@Test
 	public void testRenameMoveFileRelative1(){
-		setSource("project/");
+		setSource("C:/ws/project/");
 		currentImportUri = new LilyPondImportUri("otherDir/include.ly", "ignore", LilyPondImportUri.Type.relative);
-		assertNewUri("otherDir/include2.ly", "project/otherDir/include.ly", "project/otherDir/include2.ly");
-		assertNewUri("otherDir2/include.ly", "project/otherDir/include.ly", "project/otherDir2/include.ly");
-		assertNewUri("../otherProject/include.ly", "project/otherDir/include.ly", "otherProject/include.ly");
-		assertNewUri("../otherProject/dir/include.ly", "project/otherDir/include.ly", "otherProject/dir/include.ly");
-		assertNewUri("include2.ly", "project/otherDir/include.ly", "project/include2.ly");
-		assertNewUri("../include2.ly", "project/otherDir/include.ly", "include2.ly");
+		assertNewUri("otherDir/include2.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/project/otherDir/include2.ly");
+		assertNewUri("otherDir2/include.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/project/otherDir2/include.ly");
+		assertNewUri("other Dir2/inc lude.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/project/other Dir2/inc lude.ly");
+		assertNewUri("../otherProject/include.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/otherProject/include.ly");
+		assertNewUri("../otherProject/dir/include.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/otherProject/dir/include.ly");
+		assertNewUri("../other Project/dir/inc lude.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/other Project/dir/inc lude.ly");
+		assertNewUri("include2.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/project/include2.ly");
+		assertNewUri("../include2.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/include2.ly");
+
+		currentImportUri = new LilyPondImportUri("other Dir/inc lude.ly", "ignore", LilyPondImportUri.Type.relative);
+		assertNewUri("otherDir/include2.ly", "C:/ws/project/other Dir/inc lude.ly", "C:/ws/project/otherDir/include2.ly");
 	}
 
 	@Test
 	public void testRenameMoveFileRelative2(){
-		setSource("project/dir");
+		setSource("C:/ws/project/dir");
 		currentImportUri = new LilyPondImportUri("../otherDir/include.ly", "ignore", LilyPondImportUri.Type.relative);
-		assertNewUri("../otherDir/include2.ly", "project/otherDir/include.ly", "project/otherDir/include2.ly");
-		assertNewUri("../otherDir2/include.ly", "project/otherDir/include.ly", "project/otherDir2/include.ly");
-		assertNewUri("../../otherProject/include.ly", "project/otherDir/include.ly", "otherProject/include.ly");
-		assertNewUri("../../otherProject/dir/include.ly", "project/otherDir/include.ly", "otherProject/dir/include.ly");
+		assertNewUri("../otherDir/include2.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/project/otherDir/include2.ly");
+		assertNewUri("../otherDir2/include.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/project/otherDir2/include.ly");
+		assertNewUri("../other Dir2/inc lude.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/project/other Dir2/inc lude.ly");
+		assertNewUri("../../otherProject/include.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/otherProject/include.ly");
+		assertNewUri("../../otherProject/dir/include.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/otherProject/dir/include.ly");
+		assertNewUri("../../other Project/dir/inc lude.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/other Project/dir/inc lude.ly");
 
-		assertNewUri("include2.ly", "project/otherDir/include.ly", "project/dir/include2.ly");
+		assertNewUri("include2.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/project/dir/include2.ly");
 
-		assertNewUri("../../include2.ly", "project/otherDir/include.ly", "include2.ly");
+		assertNewUri("../../include2.ly", "C:/ws/project/otherDir/include.ly", "C:/ws/include2.ly");
 	}
 
 	@Test
 	public void testMoveIncludingFileRelative(){
-		String includeLocation= "project/otherDir/include.ly";
+		String includeLocation= "C:/ws/project/otherDir/include.ly";
 		currentImportUri = new LilyPondImportUri("otherDir/include.ly", "ignore", LilyPondImportUri.Type.relative);
-		setSource("project/","project/dir");
+		setSource("C:/ws/project/","C:/ws/project/dir");
 		assertNewUri("../otherDir/include.ly", includeLocation, includeLocation);
 
-		setSource("project/","project/otherDir");
+		setSource("C:/ws/project/","C:/ws/project/otherDir");
 		assertNewUri("include.ly", includeLocation, includeLocation);
 
-		setSource("project/","otherProject/dir");
+		setSource("C:/ws/project/","C:/ws/");
+		assertNewUri("project/otherDir/include.ly", includeLocation, includeLocation);
+
+		setSource("C:/ws/project/","C:/ws/other Project/dir");
 		assertNewUri("../../project/otherDir/include.ly", includeLocation, includeLocation);
 
 		currentImportUri = new LilyPondImportUri("../include.ly", "ignore", LilyPondImportUri.Type.relative);
-		setSource("project/dir1/dir2","project/dir3");
-		assertNewUri("../include.ly", "project/dir1/include.ly", "project/include.ly");
-		
+		setSource("C:/ws/project/dir1/dir2","C:/ws/project/dir3");
+		assertNewUri("../include.ly", "C:/ws/project/dir1/include.ly", "C:/ws/project/include.ly");
 	}
+
+//	
+//	@Test
+//	public void testSimplifyRelative1(){
+//		setSource("C:/ws/project/");
+//		currentImportUri = new LilyPondImportUri("../project/dir/include.ly", "ignore", LilyPondImportUri.Type.relative);
+//		assertNewUri("dir/include2.ly", "C:/ws/project/dir/include.ly", "C:/ws/project/dir/include2.ly");
+//	}
 
 	@Test
 	public void testRenameMoveFileFromAbsolute(){
-		setSource("project/");
-		currentImportUri = new LilyPondImportUri("/dir/include.ly", "ignore", LilyPondImportUri.Type.absolute);
-		assertNewUri("/dir/include2.ly", "dir/include.ly", "dir/include2.ly");
-		assertNewUri("/otherDir/include.ly", "dir/include.ly", "otherDir/include.ly");
-		assertNewUri("/otherDir/dir/include.ly", "dir/include.ly", "otherDir/dir/include.ly");
-
+		setSource("C:/ws/project/");
 		currentImportUri = new LilyPondImportUri("C:/dir/include.ly", "ignore", LilyPondImportUri.Type.absolute);
-		assertNewUri("C:/dir/include2.ly", "dir/include.ly", "dir/include2.ly");
-		assertNewUri("C:/otherDir/include.ly", "dir/include.ly", "otherDir/include.ly");
-		assertNewUri("C:/otherDir/dir/include.ly", "dir/include.ly", "otherDir/dir/include.ly");
+		assertNewUri("C:/dir/include2.ly", "C:/dir/include.ly", "C:/dir/include2.ly");
+		assertNewUri("C:/otherDir/include.ly", "C:/dir/include.ly", "C:/otherDir/include.ly");
+		assertNewUri("C:/otherDir/dir/include.ly", "C:/dir/include.ly", "C:/otherDir/dir/include.ly");
+		assertNewUri("C:/other Dir/dir/inc lude.ly", "C:/dir/include.ly", "C:/other Dir/dir/inc lude.ly");
 	}
 
 	@Test
 	public void testMoveIncludingFileAbsolute(){
 		String includeLocation= "ignoreAsNoChange";
-		currentImportUri = new LilyPondImportUri("/project/otherDir/include.ly", "ignore", LilyPondImportUri.Type.absolute);
-		setSource("project/","project/dir");
-		assertNewUri("/project/otherDir/include.ly", includeLocation, includeLocation);
+		currentImportUri = new LilyPondImportUri("C:/ws/project/otherDir/include.ly", "ignore", LilyPondImportUri.Type.absolute);
+		setSource("C:/ws/project/","C:/ws/project/dir");
+		assertNewUri("C:/ws/project/otherDir/include.ly", includeLocation, includeLocation);
 
-		setSource("project/","otherProject/dir1/dir2");
-		assertNewUri("/project/otherDir/include.ly", includeLocation, includeLocation);
+		setSource("C:/ws/project/","C:/ws/otherProject/dir1/dir2");
+		assertNewUri("C:/ws/project/otherDir/include.ly", includeLocation, includeLocation);
 	}
 
 	@Test
 	public void testMoveTargetAndIncludingFileAbsolut(){
-		currentImportUri = new LilyPondImportUri("/project/otherDir/include.ly", "ignore", LilyPondImportUri.Type.absolute);
-		setSource("project/","project/dir");
-		assertNewUri("include.ly", "doesNotMatter", "project/dir/include.ly");
-		assertNewUri("tidum/include.ly", "doesNotMatter", "project/dir/tidum/include.ly");
-		assertNewUri("../include.ly", "doesNotMatter", "project/include.ly");
+		currentImportUri = new LilyPondImportUri("C:/ws/project/otherDir/include.ly", "ignore", LilyPondImportUri.Type.absolute);
+		setSource("C:/ws/project/","C:/ws/project/dir");
+		assertNewUri("include.ly", "doesNotMatter", "C:/ws/project/dir/include.ly");
+		assertNewUri("tidum/include.ly", "doesNotMatter", "C:/ws/project/dir/tidum/include.ly");
+		assertNewUri("../include.ly", "doesNotMatter", "C:/ws/project/include.ly");
 	}
 
 	@Test
 	public void testSearchPath(){
 		String includeLocation= "ignoreAsNoChange";
 		currentImportUri = new LilyPondImportUri("include.ly", "ignore", LilyPondImportUri.Type.searchPath);
-		setSource("project/","project/dir");
+		setSource("C:/ws/project/","C:/ws/project/dir");
 		assertNewUri("include.ly", includeLocation, includeLocation);
-		setSource("project/dir1/dir2","project2/dir2");
+
+		setSource("C:/ws/project/dir1/dir2","C:/ws/project2/dir2");
 		assertNewUri("include.ly", includeLocation, includeLocation);
+
+		setSource("C:/ws/project/nochange");
+		assertNewUri("include2.ly", "C:/ws/searchpath/include.ly", "C:/ws/searchpath/include2.ly");
+		assertNewUri("inc lude.ly", "C:/ws/searchpath/include.ly", "C:/ws/searchpath/inc lude.ly");
+		assertNewUri("folder/include.ly", "C:/ws/searchpath/include.ly", "C:/ws/searchpath/folder/include.ly");
+		assertNewUri("fol der/inc lude.ly", "C:/ws/searchpath/include.ly", "C:/ws/searchpath/fol der/inc lude.ly");
+		assertNewUri("../include.ly", "C:/ws/searchpath/include.ly", "C:/ws/include.ly");
 	}
 
 	private void setSource(String source){
@@ -114,13 +135,33 @@ public class RefactoringIncludeHandlerTest {
 		sourceFileDestinationDir=source2;
 	}
 	private void assertNewUri(String expected, String refactoringTarget, String refactoringTargetDestinattion){
-		LilyPondRefactoredImportUriCalculator handler = getHandler(sourceFileDir, sourceFileDestinationDir, refactoringTarget, refactoringTargetDestinattion);
+		//leave all paths unmodified
+		LilyPondRefactoredImportUriCalculator handler = getHandler(sourceFileDir, sourceFileDestinationDir, refactoringTarget, refactoringTargetDestinattion, false);
 		Assert.assertEquals(expected, handler.getNewImportUri(currentImportUri));
-		handler = getHandler(sourceFileDir, sourceFileDestinationDir, "/"+refactoringTarget, "/"+refactoringTargetDestinattion);
-		Assert.assertEquals(expected, handler.getNewImportUri(currentImportUri));
+
+		//replace windows "C:" prefix in all paths by "/home" 
+		handler = getHandler(sourceFileDir, sourceFileDestinationDir, refactoringTarget, refactoringTargetDestinattion, true);
+		LilyPondImportUri importUri=new LilyPondImportUri(cToHome(currentImportUri.getOriginalUri()), cToHome(currentImportUri.getUri()), currentImportUri.getType());
+		Assert.assertEquals(cToHome(expected), handler.getNewImportUri(importUri));
 	}
 
-	private LilyPondRefactoredImportUriCalculator getHandler(String sourceDir, String sourceDestinationDir, String target, String targetDestination){
-		return new LilyPondRefactoredImportUriCalculator(new Path(sourceDir), new Path(sourceDestinationDir), new Path(target), new Path(targetDestination));
+	private LilyPondRefactoredImportUriCalculator getHandler(String sourceDir, String sourceDestinationDir, String target, String targetDestination, boolean cToHome){
+		if(!cToHome) {
+			return new LilyPondRefactoredImportUriCalculator(new Path(sourceDir), new Path(sourceDestinationDir), new Path(target), new Path(targetDestination));
+		} else {
+			Path sPath = new Path(cToHome(sourceDir));
+			Path sDestPath = new Path(cToHome(sourceDestinationDir));
+			Path tPath = new Path(cToHome(target));
+			Path tDestPath = new Path(cToHome(targetDestination));
+			return new LilyPondRefactoredImportUriCalculator(sPath, sDestPath, tPath, tDestPath);
+		}
+	}
+
+	private String cToHome(String s) {
+		if(s.startsWith("C:")) {
+			return "/home"+s.substring(2);
+		} else {
+			return s;
+		}
 	}
 }

--- a/org.elysium.parent/org.elysium.ui.tests/src/org/elysium/ui/refactoring/RefactoringIncludeHandlerTest.java
+++ b/org.elysium.parent/org.elysium.ui.tests/src/org/elysium/ui/refactoring/RefactoringIncludeHandlerTest.java
@@ -1,7 +1,6 @@
 package org.elysium.ui.refactoring;
 
 import org.eclipse.core.runtime.Path;
-import org.elysium.importuri.LilyPondImportUri;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/org.elysium.parent/org.elysium.ui.tests/src/org/elysium/ui/refactoring/RefactoringIncludeHandlerTest.java
+++ b/org.elysium.parent/org.elysium.ui.tests/src/org/elysium/ui/refactoring/RefactoringIncludeHandlerTest.java
@@ -20,7 +20,7 @@ public class RefactoringIncludeHandlerTest {
 	@Test
 	public void testRenameMoveFileRelative1(){
 		setSource("project/");
-		currentImportUri = new LilyPondImportUri("otherDir/include.ly", "ignore", LilyPondImportUri.Type.relative, true);
+		currentImportUri = new LilyPondImportUri("otherDir/include.ly", "ignore", LilyPondImportUri.Type.relative);
 		assertNewUri("otherDir/include2.ly", "project/otherDir/include.ly", "project/otherDir/include2.ly");
 		assertNewUri("otherDir2/include.ly", "project/otherDir/include.ly", "project/otherDir2/include.ly");
 		assertNewUri("../otherProject/include.ly", "project/otherDir/include.ly", "otherProject/include.ly");
@@ -32,7 +32,7 @@ public class RefactoringIncludeHandlerTest {
 	@Test
 	public void testRenameMoveFileRelative2(){
 		setSource("project/dir");
-		currentImportUri = new LilyPondImportUri("../otherDir/include.ly", "ignore", LilyPondImportUri.Type.relative, true);
+		currentImportUri = new LilyPondImportUri("../otherDir/include.ly", "ignore", LilyPondImportUri.Type.relative);
 		assertNewUri("../otherDir/include2.ly", "project/otherDir/include.ly", "project/otherDir/include2.ly");
 		assertNewUri("../otherDir2/include.ly", "project/otherDir/include.ly", "project/otherDir2/include.ly");
 		assertNewUri("../../otherProject/include.ly", "project/otherDir/include.ly", "otherProject/include.ly");
@@ -46,7 +46,7 @@ public class RefactoringIncludeHandlerTest {
 	@Test
 	public void testMoveIncludingFileRelative(){
 		String includeLocation= "project/otherDir/include.ly";
-		currentImportUri = new LilyPondImportUri("otherDir/include.ly", "ignore", LilyPondImportUri.Type.relative, true);
+		currentImportUri = new LilyPondImportUri("otherDir/include.ly", "ignore", LilyPondImportUri.Type.relative);
 		setSource("project/","project/dir");
 		assertNewUri("../otherDir/include.ly", includeLocation, includeLocation);
 
@@ -56,7 +56,7 @@ public class RefactoringIncludeHandlerTest {
 		setSource("project/","otherProject/dir");
 		assertNewUri("../../project/otherDir/include.ly", includeLocation, includeLocation);
 
-		currentImportUri = new LilyPondImportUri("../include.ly", "ignore", LilyPondImportUri.Type.relative, true);
+		currentImportUri = new LilyPondImportUri("../include.ly", "ignore", LilyPondImportUri.Type.relative);
 		setSource("project/dir1/dir2","project/dir3");
 		assertNewUri("../include.ly", "project/dir1/include.ly", "project/include.ly");
 		
@@ -65,12 +65,12 @@ public class RefactoringIncludeHandlerTest {
 	@Test
 	public void testRenameMoveFileFromAbsolute(){
 		setSource("project/");
-		currentImportUri = new LilyPondImportUri("/dir/include.ly", "ignore", LilyPondImportUri.Type.absolute, true);
+		currentImportUri = new LilyPondImportUri("/dir/include.ly", "ignore", LilyPondImportUri.Type.absolute);
 		assertNewUri("/dir/include2.ly", "dir/include.ly", "dir/include2.ly");
 		assertNewUri("/otherDir/include.ly", "dir/include.ly", "otherDir/include.ly");
 		assertNewUri("/otherDir/dir/include.ly", "dir/include.ly", "otherDir/dir/include.ly");
 
-		currentImportUri = new LilyPondImportUri("C:/dir/include.ly", "ignore", LilyPondImportUri.Type.absolute, true);
+		currentImportUri = new LilyPondImportUri("C:/dir/include.ly", "ignore", LilyPondImportUri.Type.absolute);
 		assertNewUri("C:/dir/include2.ly", "dir/include.ly", "dir/include2.ly");
 		assertNewUri("C:/otherDir/include.ly", "dir/include.ly", "otherDir/include.ly");
 		assertNewUri("C:/otherDir/dir/include.ly", "dir/include.ly", "otherDir/dir/include.ly");
@@ -79,7 +79,7 @@ public class RefactoringIncludeHandlerTest {
 	@Test
 	public void testMoveIncludingFileAbsolute(){
 		String includeLocation= "ignoreAsNoChange";
-		currentImportUri = new LilyPondImportUri("/project/otherDir/include.ly", "ignore", LilyPondImportUri.Type.absolute, true);
+		currentImportUri = new LilyPondImportUri("/project/otherDir/include.ly", "ignore", LilyPondImportUri.Type.absolute);
 		setSource("project/","project/dir");
 		assertNewUri("/project/otherDir/include.ly", includeLocation, includeLocation);
 
@@ -89,7 +89,7 @@ public class RefactoringIncludeHandlerTest {
 
 	@Test
 	public void testMoveTargetAndIncludingFileAbsolut(){
-		currentImportUri = new LilyPondImportUri("/project/otherDir/include.ly", "ignore", LilyPondImportUri.Type.absolute, true);
+		currentImportUri = new LilyPondImportUri("/project/otherDir/include.ly", "ignore", LilyPondImportUri.Type.absolute);
 		setSource("project/","project/dir");
 		assertNewUri("include.ly", "doesNotMatter", "project/dir/include.ly");
 		assertNewUri("tidum/include.ly", "doesNotMatter", "project/dir/tidum/include.ly");
@@ -99,7 +99,7 @@ public class RefactoringIncludeHandlerTest {
 	@Test
 	public void testSearchPath(){
 		String includeLocation= "ignoreAsNoChange";
-		currentImportUri = new LilyPondImportUri("include.ly", "ignore", LilyPondImportUri.Type.searchPath, true);
+		currentImportUri = new LilyPondImportUri("include.ly", "ignore", LilyPondImportUri.Type.searchPath);
 		setSource("project/","project/dir");
 		assertNewUri("include.ly", includeLocation, includeLocation);
 		setSource("project/dir1/dir2","project2/dir2");

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/DeleteFileParticipant.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/DeleteFileParticipant.java
@@ -16,6 +16,7 @@ public class DeleteFileParticipant extends DeleteParticipant {
 
 	@Inject
 	LilyPondRefactoringInjects injects;
+	LilyPondRefactoringDelegate delegate;
 
 	private IFile sourceFile;
 
@@ -32,12 +33,13 @@ public class DeleteFileParticipant extends DeleteParticipant {
 
 	@Override
 	public RefactoringStatus checkConditions(IProgressMonitor pm, CheckConditionsContext context) throws OperationCanceledException {
-		LilyPondRefactoringDelegate.get(Operation.delete, context, injects).addFileToRefactor(sourceFile , getArguments());
+		delegate=LilyPondRefactoringDelegate.get(Operation.delete, context, injects);
+		delegate.addFileToRefactor(sourceFile , getArguments());
 		return new RefactoringStatus();
 	}
 
 	@Override
 	public Change createChange(IProgressMonitor pm) throws CoreException, OperationCanceledException {
-		return null;
+		return delegate.apply(pm);
 	}
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondImportUri.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondImportUri.java
@@ -1,10 +1,11 @@
-package org.elysium.importuri;
+package org.elysium.ui.refactoring;
 
 import com.google.common.base.Objects;
 
 public class LilyPondImportUri {
 
 	public enum Type{
+		unresolved,
 		relative,
 		absolute,
 		searchPath

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoredImportUriCalculator.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoredImportUriCalculator.java
@@ -4,7 +4,6 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
-import org.elysium.importuri.LilyPondImportUri;
 
 //if package private - maven build fails due to
 //https://stackoverflow.com/questions/36100552/illegalaccesserror-when-using-a-public-method-reference-of-a-package-private-cla
@@ -13,7 +12,7 @@ public class LilyPondRefactoredImportUriCalculator {
 
 	//source file parent location before refactoring
 	private IPath source;
-	//source file parent location before refactoring
+	//source file parent location after refactoring
 	private IPath sourceDestiation;
 	//include location before refactoring
 	private IPath target;
@@ -54,6 +53,7 @@ public class LilyPondRefactoredImportUriCalculator {
 	 * */
 	public String getNewImportUri(LilyPondImportUri importUri){
 		switch(importUri.getType()){
+			case unresolved: return importUri.getOriginalUri();
 			case absolute:return handleAbsolute(importUri);
 			case searchPath:return handelSearchPath(importUri);
 			default:return handleRelative(importUri);

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoredImportUriCalculator.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoredImportUriCalculator.java
@@ -32,7 +32,6 @@ public class LilyPondRefactoredImportUriCalculator {
 		this.sourceDestiation=sourceContainerDestiation;
 		this.target=target;
 		this.targetDestination=targetDestination;
-		//TODO adapt tests to absolute locaion and write more of them (windows/unix)
 	}
 
 	//when renaming a project, the sorceDestination parent location is null causing an NPE
@@ -89,6 +88,7 @@ public class LilyPondRefactoredImportUriCalculator {
 			//absolute location is still correct
 			return importUri.getOriginalUri();
 		} else if(source.equals(sourceDestiation)){
+			//TODO use target destination directly, as it is already an absolute path?
 			//source is same - emulate navigation of target
 			IPath targetNavigate=targetDestination.makeRelativeTo(target);
 			IPath navigated = origURI.append(targetNavigate);

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoring.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoring.java
@@ -29,6 +29,7 @@ import org.eclipse.ltk.core.refactoring.participants.DeleteRefactoring;
 import org.eclipse.ltk.core.refactoring.participants.MoveArguments;
 import org.eclipse.ltk.core.refactoring.participants.RefactoringArguments;
 import org.eclipse.ltk.core.refactoring.participants.RenameArguments;
+import org.eclipse.ltk.core.refactoring.resource.DeleteResourceChange;
 import org.eclipse.ltk.core.refactoring.resource.MoveResourceChange;
 import org.eclipse.ltk.core.refactoring.resource.RenameResourceChange;
 import org.eclipse.ltk.internal.core.refactoring.resource.DeleteResourcesProcessor;
@@ -178,6 +179,8 @@ class LilyPondRefactoring {
 			return compiledChangeWithClosingScoreView(compiled,new RenameResourceChange(compiled.getFullPath(), newName));
 		case move:
 			return compiledChangeWithClosingScoreView(compiled, new MoveResourceChange(compiled, (IContainer)((MoveArguments)arguments).getDestination()));
+		case delete:
+			return compiledChangeWithClosingScoreView(compiled, new DeleteResourceChange(compiled.getFullPath(), true));
 		default:
 			break;
 		}

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoringDelegate.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoringDelegate.java
@@ -20,6 +20,11 @@ import org.eclipse.ltk.core.refactoring.participants.ResourceChangeChecker;
 import org.eclipse.xtext.resource.IResourceDescription;
 import org.elysium.ui.Activator;
 
+/**
+ * wrapper for a single refactoring operation
+ * 
+ * ... regardless of the type of refactoring and how many resources are involved
+ * */
 class LilyPondRefactoringDelegate implements IConditionChecker{
 
 	public static final String NAME = "Update LilyPond references";
@@ -119,6 +124,7 @@ class LilyPondRefactoringDelegate implements IConditionChecker{
 		ref.addContainerToRefactor(container, arguments);
 	}
 
+	//TODO call only if new preference says "Do automatic include refactoring"
 	public Change adaptIncludes(IProgressMonitor monitor){
 		if(preChangeAlreadyCreated || monitor.isCanceled()){
 			return null;

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoringInjects.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoringInjects.java
@@ -56,10 +56,12 @@ class LilyPondRefactoringInjects {
 	}
 
 	public LilyPondImportUri resolveImportUri(URI baseURI, String importUri) {
+		boolean absolute=LilyPondImportUriResolver.isAbsolute(importUri, LilyPondConstants.IS_WINDOWS);
 		LilyPondResolvedUri resolved=uriResolver.resolve(baseURI, importUri);
 		//TODO this is temporary, so that compile works
 		//LilyPondUri needs to be replaced
-		return new LilyPondImportUri(importUri, resolved.get(), Type.relative, true);
+		//TODO search path include is relevant!!
+		return new LilyPondImportUri(importUri, resolved.get(), absolute?Type.absolute:Type.relative);
 	}
 
 	public List<String> getSearchPaths() {

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondSourceFileRefactoring.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondSourceFileRefactoring.java
@@ -28,7 +28,6 @@ import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.IEObjectDescription;
 import org.eclipse.xtext.resource.IReferenceDescription;
 import org.eclipse.xtext.resource.IResourceDescription;
-import org.elysium.importuri.LilyPondImportUri;
 import org.elysium.lilypond.Include;
 import org.elysium.lilypond.LilypondPackage;
 import org.elysium.ui.refactoring.LilyPondRefactoringDelegate.Operation;

--- a/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUri.java
+++ b/org.elysium.parent/org.elysium/src/org/elysium/importuri/LilyPondImportUri.java
@@ -13,13 +13,11 @@ public class LilyPondImportUri {
 	private String originalUri;
 	private String uri;
 	private Type type;
-	private boolean inWorkspace;
 
-	public LilyPondImportUri(String originalUri, String uri, Type type, boolean inWorkspace) {
+	public LilyPondImportUri(String originalUri, String uri, Type type) {
 		this.originalUri=originalUri;
 		this.uri=uri;
 		this.type=type;
-		this.inWorkspace=inWorkspace;
 	}
 
 	public String getUri() {
@@ -32,7 +30,7 @@ public class LilyPondImportUri {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this).add("type", type.toString()).add("inWS", inWorkspace).add("resolved", uri).toString();
+		return Objects.toStringHelper(this).add("type", type.toString()).add("resolved", uri).toString();
 	}
 
 	public Type getType() {


### PR DESCRIPTION
This PR addresses #134.
* refactorings have been adapted to file system location rather than workspace project relative location
* resolution unit tests for windows and unix paths (given that the paths given as arguments are correct)
* delete of source file deletes compiled files as well (analogous to rename/move)
* I have tried out the refactorings for relative, absolute and search path includes on a windows and a linux machine.

The current implementation has some small limitations
* refactoring involving virtual folders/linked files will probably fail (e.g. renaming a linked file renames only the link, not the underlying file)
* refactorings (involving search path relative includes) moving included/included files into/out of the search path may cause problems

I guess search paths are usually used for default includes which are more or less static (so refactoring will not really happen). Virtual folders/linked files will probably hardly used. So these limitations are not too problematic.

What do you think of the following enhancements for the refactoring preference page; add preferecence
* for disabling Refactoring participant completely (default refactoring enabled)
* for disabling automatic include modification (default include modification enabled)
* for disabling "delete included file" warning (default warning enabled)
* for disabling deleting compiled files when deleting a source (default deleting compiled enabled)

I will address the following issues next
* Score may produce more than one midi file, refactorings should deal with all of them
* detect virtual folders/linked files and don't do refactorings then