### PR TITLE
Problem parsing minimal

### DIFF
--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CancellableProcessUtils.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CancellableProcessUtils.java
@@ -45,7 +45,7 @@ public class CancellableProcessUtils {
 			new Thread(new Runnable() {
 				@Override
 				public void run() {
-					BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()));
+					BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
 					String line;
 					try {
 						while ((line = reader.readLine()) != null) {

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerProcessBuilderFactory.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerProcessBuilderFactory.java
@@ -51,6 +51,7 @@ public class CompilerProcessBuilderFactory {
 			command.addAll(Lists.newArrayList(preferenceStore.getString(CompilerPreferenceConstants.COMMAND_LINE.name()).split("\\n")));
 		}
 		processBuilder.command(command);
+		processBuilder.redirectErrorStream(true);
 		return processBuilder;
 	}
 

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerProcessBuilderFactory.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerProcessBuilderFactory.java
@@ -94,7 +94,7 @@ public class CompilerProcessBuilderFactory {
 
 		Map<String, String> environment = processBuilder.environment();
 		Locale locale = Locale.getDefault();
-		environment.put("LANG", locale.toString()); //$NON-NLS-1$
+		environment.put("LANG", locale.toString()+".UTF-8"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/ProblemParser.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/ProblemParser.java
@@ -1,8 +1,9 @@
 package org.elysium.ui.compiler.problems;
 
-import static com.google.common.base.Objects.firstNonNull;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
@@ -14,6 +15,7 @@ import org.elysium.LilyPondConstants;
 import org.elysium.ui.Activator;
 import org.elysium.ui.markers.MarkerAttributes;
 import org.elysium.ui.markers.MarkerTypes;
+
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -49,7 +51,7 @@ public class ProblemParser {
 	/**
 	 * The string denoting error in the locale used by LilyPond.
 	 */
-	protected static final String ERROR_STRING = firstNonNull(ERROR_STRINGS.get(Locale.getDefault().getLanguage()), "error") + PROBLEM_POSTFIX; //$NON-NLS-1$
+	protected static final String ERROR_STRING = Optional.ofNullable(ERROR_STRINGS.get(Locale.getDefault().getLanguage())).orElse("error") + PROBLEM_POSTFIX; //$NON-NLS-1$
 
 	/**
 	 * Strings with which programming error messages start in the appropriate
@@ -67,7 +69,7 @@ public class ProblemParser {
 	 * The string with which programming error messages start in the locale used
 	 * by LilyPond.
 	 */
-	protected static final String PROGRAMMING_ERROR_PREFIX = firstNonNull(PROGRAMMING_ERROR_PREFIXES.get(Locale.getDefault().getLanguage()), "programming"); //$NON-NLS-1$
+	protected static final String PROGRAMMING_ERROR_PREFIX = Optional.ofNullable(PROGRAMMING_ERROR_PREFIXES.get(Locale.getDefault().getLanguage())).orElse("programming"); //$NON-NLS-1$
 
 	/**
 	 * Strings denoting warning in all locales LilyPond is available in.
@@ -92,7 +94,7 @@ public class ProblemParser {
 	/**
 	 * The string denoting warning in the locale used by LilyPond.
 	 */
-	protected static final String WARNING_STRING = firstNonNull(WARNING_STRINGS.get(Locale.getDefault().getLanguage()), "warning") + PROBLEM_POSTFIX; //$NON-NLS-1$
+	protected static final String WARNING_STRING = Optional.ofNullable(WARNING_STRINGS.get(Locale.getDefault().getLanguage())).orElse("warning") + PROBLEM_POSTFIX; //$NON-NLS-1$
 
 	/**
 	 * @param file the file being compiled


### PR DESCRIPTION
This PR tries to improve LilyPond compile error parsing. The error stream is redirected (see java doc) so that messages will not get lost, even if errors were somehow globally redirected to the regular output. The second change is adding the encoding to the locale - otherwise the output remained English even though the locale was German.

Testet on a Windows and a Linux system, to be confirmed on Mac.

These two commits should not be problematc. I still think that the Problem parser should not depend on the locale directly. As seen by #178, even though the locale may be set, LilyPond could use a different language. This language should be inferred directly from the console output.