### PR TITLE
#178 add problem parse language fallback

### DIFF
--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerOutputProcessor.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerOutputProcessor.java
@@ -18,9 +18,9 @@ import org.elysium.ui.markers.MarkerTypes;
 public class CompilerOutputProcessor implements OutputProcessor {
 
 	/**
-	 * The file being compiled.
+	 * The problem parser for the file being compiled.
 	 */
-	private final IFile file;
+	private final ProblemParser problemParser;
 
 	/**
 	 * The console to which the compiler's output is written.
@@ -28,14 +28,14 @@ public class CompilerOutputProcessor implements OutputProcessor {
 	private final LilyPondConsole console;
 
 	public CompilerOutputProcessor(IFile file, LilyPondConsole console) {
-		this.file = file;
 		this.console = console;
+		this.problemParser=new ProblemParser(file);
 	}
 
 	@Override
 	public void processOutput(String line) {
 		console.print(line);
-		IMarker problemMarker = ProblemParser.parse(file, line);
+		IMarker problemMarker = problemParser.parse(line);
 		if (problemMarker != null) {
 			// If file already contains problem, delete it
 			try {

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerOutputProcessor.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerOutputProcessor.java
@@ -35,6 +35,9 @@ public class CompilerOutputProcessor implements OutputProcessor {
 	@Override
 	public void processOutput(String line) {
 		console.print(line);
+		//TODO the problem parser may find an existing file for an issue even though
+		//it is not in the workspace, so no marker can be added
+		//but a hyperlink to the file may nevertheless be created
 		IMarker problemMarker = problemParser.parse(line);
 		if (problemMarker != null) {
 			// If file already contains problem, delete it

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerOutputProcessor.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerOutputProcessor.java
@@ -7,8 +7,6 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.ui.console.IHyperlink;
-import org.eclipse.ui.views.pdf.PdfAnnotation;
-import org.eclipse.util.TextEditorUtils;
 import org.elysium.ui.Activator;
 import org.elysium.ui.compiler.console.LilyPondConsole;
 import org.elysium.ui.compiler.problems.ProblemHyperlinkAdder;
@@ -40,7 +38,7 @@ public class CompilerOutputProcessor implements OutputProcessor {
 	public void processOutput(String line) {
 		console.print(line);
 		IMarker problemMarker = problemParser.parse(line);
-		final PdfAnnotation wsExternalIssue =problemParser.getWorkspaceExternalIssue();
+		IHyperlink wsExternalIssue =problemParser.getWorkspaceExternalHyperlink();
 		if (problemMarker != null) {
 			// If file already contains problem, delete it
 			try {
@@ -58,23 +56,7 @@ public class CompilerOutputProcessor implements OutputProcessor {
 			// Add hyperlink in any case
 			ProblemHyperlinkAdder.add(console, problemMarker, line);
 		} else if(wsExternalIssue != null) {
-			IHyperlink hyperlink=new IHyperlink() {
-				
-				@Override
-				public void linkExited() {}
-				
-				@Override
-				public void linkEntered() {}
-				
-				@Override
-				public void linkActivated() {
-					//TODO if we are really good, we could add an annotation
-					//corresponding to the issue to the editor just opened
-					TextEditorUtils.revealPosition(wsExternalIssue.fileURI, wsExternalIssue.lineNumber, wsExternalIssue.columnNumber, 1);
-				}
-			};
-			ProblemHyperlinkAdder.add(console, hyperlink, line);
+			ProblemHyperlinkAdder.add(console, wsExternalIssue, line);
 		}
 	}
-
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/LilyPondWorkspaceExternalHyperlink.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/LilyPondWorkspaceExternalHyperlink.java
@@ -1,20 +1,42 @@
 package org.elysium.ui.compiler.problems;
 
 import java.net.URI;
+import java.util.List;
 
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.console.IHyperlink;
+import org.eclipse.util.DocumentUtils;
+import org.eclipse.util.EditorUtils;
 import org.eclipse.util.TextEditorUtils;
+import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.xbase.lib.IteratorExtensions;
+import org.elysium.LilyPondConstants;
+import org.elysium.ui.LilyPondXtextEditor;
 
-class LilyPondWorkspaceExternalHyperlink implements IHyperlink {
+class LilyPondWorkspaceExternalHyperlink implements IHyperlink{
+
+	//types from org.eclipse.ui.editors plugin.xml
+	private static final String ERROR_ANNOTATION = "org.eclipse.ui.workbench.texteditor.error";
+	private static final String WARNING_ANNOTATION = "org.eclipse.ui.workbench.texteditor.warning";
 
 	private URI file;
 	private int line;
 	private int column;
+	private String message;
+	private int severity;
+	private List<LilyPondWorkspaceExternalHyperlink> allFileIssues;
 
-	public LilyPondWorkspaceExternalHyperlink(URI file, int line, int column) {
+	public LilyPondWorkspaceExternalHyperlink(URI file, int line, int column, String message, int severity) {
 		this.file = file;
 		this.line = line;
 		this.column = column;
+		this.message = message;
+		this.severity = severity;
 	}
 
 	@Override
@@ -25,9 +47,37 @@ class LilyPondWorkspaceExternalHyperlink implements IHyperlink {
 
 	@Override
 	public void linkActivated() {
-		//TODO if we are really good, we could add an annotation with the error text
-		//corresponding to the issue to the editor just opened
 		TextEditorUtils.revealPosition(file, line, column, 1);
+		IEditorPart editor = EditorUtils.getActiveEditor();
+		if(editor instanceof LilyPondXtextEditor) {
+			addAnnotations((LilyPondXtextEditor)editor);
+		}
 	}
 
+	private void addAnnotations(LilyPondXtextEditor editor) {
+		IAnnotationModel annotationModel = ((LilyPondXtextEditor) editor).getInternalSourceViewer()
+				.getAnnotationModel();
+		boolean annotationsPresent = IteratorExtensions.size(annotationModel.getAnnotationIterator()) > 0;
+		if (!annotationsPresent) {
+			IXtextDocument document = editor.getDocument();
+			for (LilyPondWorkspaceExternalHyperlink issue : allFileIssues) {
+				String type = ERROR_ANNOTATION;
+				if (issue.severity == IMarker.SEVERITY_WARNING) {
+					type = WARNING_ANNOTATION;
+				}
+				int offset;
+				try {
+					offset = DocumentUtils.getOffsetOfPosition(document, issue.line, issue.column,
+							LilyPondConstants.TAB_WIDTH);
+					annotationModel.addAnnotation(new Annotation(type, false, issue.message), new Position(offset, 0));
+				} catch (BadLocationException e) {
+					// ignore
+				}
+			}
+		}
+	}
+
+	public void setFileLinks(List<LilyPondWorkspaceExternalHyperlink> allFileLinkes) {
+		allFileIssues=allFileLinkes;
+	}
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/LilyPondWorkspaceExternalHyperlink.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/LilyPondWorkspaceExternalHyperlink.java
@@ -1,0 +1,33 @@
+package org.elysium.ui.compiler.problems;
+
+import java.net.URI;
+
+import org.eclipse.ui.console.IHyperlink;
+import org.eclipse.util.TextEditorUtils;
+
+class LilyPondWorkspaceExternalHyperlink implements IHyperlink {
+
+	private URI file;
+	private int line;
+	private int column;
+
+	public LilyPondWorkspaceExternalHyperlink(URI file, int line, int column) {
+		this.file = file;
+		this.line = line;
+		this.column = column;
+	}
+
+	@Override
+	public void linkEntered() {}
+
+	@Override
+	public void linkExited() {}
+
+	@Override
+	public void linkActivated() {
+		//TODO if we are really good, we could add an annotation with the error text
+		//corresponding to the issue to the editor just opened
+		TextEditorUtils.revealPosition(file, line, column, 1);
+	}
+
+}

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/ProblemHyperlinkAdder.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/ProblemHyperlinkAdder.java
@@ -62,6 +62,10 @@ public class ProblemHyperlinkAdder implements IDocumentPartitioningListener {
 	 */
 	public static void add(TextConsole console, IMarker problemMarker, String line) {
 		MarkerHyperlink hyperlink = new MarkerHyperlink(problemMarker);
+		add(console, hyperlink, line);
+	}
+
+	public static void add(TextConsole console, IHyperlink hyperlink, String line) {
 		// Add hyperlink when its text is already processed in a job by the console's document partitioner
 		ProblemHyperlinkAdder hyperlinkAdder = new ProblemHyperlinkAdder(console, hyperlink, line);
 		console.getDocument().addDocumentPartitioningListener(hyperlinkAdder);

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/ProblemParser.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/ProblemParser.java
@@ -179,21 +179,29 @@ public class ProblemParser {
 				if ((includedResource != null) && (includedResource instanceof IFile)) {
 					return (IFile)includedResource;
 				} else {
-					File maybeAbsoluteFile=new File(path);
-					if(maybeAbsoluteFile.exists()) {
-						IFile[] files = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(maybeAbsoluteFile.toURI());
+					File file=getFileFromPath(path);
+					if(file.exists()) {
+						IFile[] files = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(file.toURI());
 						for (IFile iFile : files) {
 							if(iFile.exists()) {
 								return iFile;
 							}
 						}
-						initWorkspaceExternalIssue(maybeAbsoluteFile, line, infoSections);
+						initWorkspaceExternalIssue(file, line, infoSections);
 					}
 					return null;
 				}
 			}
 		}
 		return compiledFile;
+	}
+
+	private File getFileFromPath(String path) {
+		File file=new File(path);
+		if(!file.exists()) {
+			file=compiledFile.getLocation().removeLastSegments(1).append(path).toFile();
+		}
+		return file;
 	}
 
 	private String getMessage(String line) {

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/ProblemParser.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/ProblemParser.java
@@ -12,7 +12,7 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
-import org.eclipse.ui.views.pdf.PdfAnnotation;
+import org.eclipse.ui.console.IHyperlink;
 import org.eclipse.util.DocumentUtils;
 import org.elysium.LilyPondConstants;
 import org.elysium.ui.Activator;
@@ -100,7 +100,7 @@ public class ProblemParser {
 	int severity;
 	int problemStringIndex;
 	int messageIndex;
-	private PdfAnnotation wsExternalIssueRepresentative;
+	private LilyPondWorkspaceExternalHyperlink wsExternalHyperlink;
 
 	public ProblemParser(IFile file) {
 		this.compiledFile = file;
@@ -110,7 +110,7 @@ public class ProblemParser {
 		severity = IMarker.SEVERITY_INFO;
 		problemStringIndex = -1;
 		messageIndex = -1;
-		wsExternalIssueRepresentative=null;
+		wsExternalHyperlink = null;
 		boolean lineCanContainIssue=line.indexOf(':') >= 0;
 		if(lineCanContainIssue) {
 			determineIndexesAndSeverityByLanguage(line, language);
@@ -144,11 +144,9 @@ public class ProblemParser {
 	}
 
 	private void initWorkspaceExternalIssue(File existingFile, String[] infoSections) {
-		PdfAnnotation annotation = new PdfAnnotation();
-		annotation.fileURI = existingFile.toURI();
-		annotation.lineNumber = toNumber(infoSections, 1);
-		annotation.columnNumber = toNumber(infoSections, 2);
-		wsExternalIssueRepresentative=annotation;
+		int line = toNumber(infoSections, 1);
+		int column = toNumber(infoSections, 2);
+		wsExternalHyperlink = new LilyPondWorkspaceExternalHyperlink(existingFile.toURI(), line, column);
 	}
 
 	private int toNumber(String[] infoSections, int index) {
@@ -258,7 +256,7 @@ public class ProblemParser {
 		return null;
 	}
 
-	public PdfAnnotation getWorkspaceExternalIssue() {
-		return wsExternalIssueRepresentative;
+	public IHyperlink getWorkspaceExternalHyperlink() {
+		return wsExternalHyperlink;
 	}
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/ProblemParser.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/problems/ProblemParser.java
@@ -92,7 +92,7 @@ public class ProblemParser {
 	 * The language passed to the LilyPond compile for localization
 	 */
 	private final String language=Locale.getDefault().getLanguage();
-	private static final String FALLBACK_LANGUAGE="en"; //$NON-NLS-1$
+	private static final String FALLBACK_LANGUAGE = "en"; //$NON-NLS-1$
 
 	int severity;
 	int problemStringIndex;
@@ -106,9 +106,12 @@ public class ProblemParser {
 		severity = IMarker.SEVERITY_INFO;
 		problemStringIndex = -1;
 		messageIndex = -1;
-		determineIndexesAndSeverityByLanguage(line, language);
-		if(severity == IMarker.SEVERITY_INFO) {
-			determineIndexesAndSeverityByLanguage(line, FALLBACK_LANGUAGE);
+		boolean lineCanContainIssue=line.indexOf(':') >= 0;
+		if(lineCanContainIssue) {
+			determineIndexesAndSeverityByLanguage(line, language);
+			if(severity == IMarker.SEVERITY_INFO) {
+				determineIndexesAndSeverityByLanguage(line, FALLBACK_LANGUAGE);
+			}
 		}
 	}
 

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondTargetUriCollector.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/hyperlinks/LilyPondTargetUriCollector.java
@@ -20,7 +20,7 @@ public class LilyPondTargetUriCollector extends TargetURICollector {
 			//so check if file exists in workspace and add as search URI
 			if(uri.isFile()) {
 				String fragment = uri.fragment();
-				//TODO similar findFilesForLocationURI for file URIS is now used in LilyPondProposalProvider, LilyPondHyperlinkHelper, LilyPondLanguageSpecificURIEditorOpener and here
+				//TODO similar findFilesForLocationURI for file URIS is now used in LilyPondProposalProvider, LilyPondHyperlinkHelper, LilyPondLanguageSpecificURIEditorOpener, ProblemParser and here
 				IFile[] files = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(java.net.URI.create(uri.toString()));
 				for (IFile iFile : files) {
 					if(iFile.exists()) {


### PR DESCRIPTION
This PR implements the language fallback discussed in #178. Mostly, it is refactoring splitting up of the previously static parse method. There is a second reason for introducing state to the problem parser. Determining the file with the issue will have to be adapted. The current implementation can easily fail for more complex include constallations.

Checking the path against the include information present in the index may help improve finding the file to mark.