### PR TITLE
link file view only if compiled file may exist

### DIFF
--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/audio/AudioViewType.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/audio/AudioViewType.java
@@ -3,6 +3,7 @@ package org.elysium.ui.audio;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.ui.views.midi.MidiViewType;
 import org.eclipse.util.ResourceUtils;
+import org.elysium.LilyPondConstants;
 import org.elysium.ui.Activator;
 
 /**
@@ -17,7 +18,16 @@ public class AudioViewType extends MidiViewType {
 	 */
 	@Override
 	public IFile getFile(IFile sourceFile) {
-		return ResourceUtils.replaceExtension(sourceFile, EXTENSION);
+		String replaceExtension = "dontshow"; //$NON-NLS-1$
+		if(mayHaveMatchingMidi(sourceFile)) {
+			replaceExtension = EXTENSION;
+		}
+		return ResourceUtils.replaceExtension(sourceFile, replaceExtension);
+	}
+
+	private boolean mayHaveMatchingMidi(IFile sourceFile) {
+		String extension=sourceFile.getFileExtension();
+		return LilyPondConstants.EXTENSION.equals(extension) || LilyPondConstants.COMPILED_EXTENSIONS.contains(extension);
 	}
 
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/score/ScoreViewType.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/score/ScoreViewType.java
@@ -10,6 +10,7 @@ import org.eclipse.ui.views.pdf.PdfViewPage;
 import org.eclipse.ui.views.pdf.PdfViewType;
 import org.eclipse.util.ResourceUtils;
 import org.eclipse.util.UiUtils;
+import org.elysium.LilyPondConstants;
 import org.elysium.ui.Activator;
 
 /**
@@ -24,7 +25,16 @@ public class ScoreViewType extends PdfViewType {
 	 */
 	@Override
 	public IFile getFile(IFile sourceFile) {
-		return ResourceUtils.replaceExtension(sourceFile, EXTENSION);
+		String replaceExtension = "dontshow"; //$NON-NLS-1$
+		if(mayHaveMatchingPdf(sourceFile)) {
+			replaceExtension = EXTENSION;
+		}
+		return ResourceUtils.replaceExtension(sourceFile, replaceExtension);
+	}
+
+	private boolean mayHaveMatchingPdf(IFile sourceFile) {
+		String extension=sourceFile.getFileExtension();
+		return LilyPondConstants.EXTENSION.equals(extension) || LilyPondConstants.COMPILED_EXTENSIONS.contains(extension);
 	}
 
 	public static IFile getScoreFile() {


### PR DESCRIPTION
Currently, if score view/audio view are open and "linked" with the selected file, changing selection to a file that may not have a corresponding compiled file shows the "pdf/midi file does not exists" warning.

Generally, I like the link with editor functionality, but it is irritating if you jump from the score to an ily-file and the score disappears. The selection change listener in FileView is not null safe, so what I do is returning a file with a dummy extension in case the selected file cannot be the source file of a potential pdf/midi file.