### PR TITLE
wait for all compile output to be processed

### DIFF
--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CancellableProcessUtils.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CancellableProcessUtils.java
@@ -41,7 +41,7 @@ public class CancellableProcessUtils {
 		}, "Canceller for "+processName).start();
 
 		try{
-			new Thread(new Runnable() {
+			Thread consoleThread = new Thread(new Runnable() {
 				@Override
 				public void run() {
 					BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
@@ -55,8 +55,10 @@ public class CancellableProcessUtils {
 					}
 				}
 				
-			}, processName).start();
+			}, processName);
+			consoleThread.start();
 			process.waitFor();
+			consoleThread.join();
 		}finally{
 			done.set(true);
 		}


### PR DESCRIPTION
As the compiler output processing happens in a separate thread, it was possible, that the run method returned (and the "LilyPond terminated ..." message was written to the console) before all the output was written.

This change causes the run method to wait for all the compile output to be written before returning, so the termination message is always written last.

... When compiling an entire folder/project, currently for each compiled file a project refresh is invoked. I was playing around with waiting for all files to be compiled before refreshing all involved projects once. This works but it has one drawback. If one of the compiled files is open in the score view, the score is updated only after all compilations are finished. I guess, this is OK for the general use case (recompile during build and recompile viewed invoke compilation only for one file, so there is no difference; and for compiling many files the number of project refreshs is much reduced). Do you think this change makes sense?