### PR TITLE
recompile only outdated when container is selected

### DIFF
--- a/org.elysium.parent/org.elysium.ui/plugin.xml
+++ b/org.elysium.parent/org.elysium.ui/plugin.xml
@@ -83,7 +83,16 @@
   <extension point="org.eclipse.ui.commands">
     <command id="org.elysium.ui.commands.RecompileEdited" name="Recompile Edited" categoryId="org.elysium.ui.commandCategories.LilyPond"/>
 	<command id="org.elysium.ui.commands.RecompileViewed" name="Recompile Viewed" categoryId="org.elysium.ui.commandCategories.LilyPond"/>
-    <command id="org.elysium.ui.commands.RecompileSelected" name="Recompile" categoryId="org.elysium.ui.commandCategories.LilyPond"/>
+    <command
+          categoryId="org.elysium.ui.commandCategories.LilyPond"
+          id="org.elysium.ui.commands.RecompileSelected"
+          name="Recompile">
+       <commandParameter
+             id="org.elysium.ui.commands.RecompileSelected.outdatedOnly"
+             name="name"
+             optional="true">
+       </commandParameter>
+    </command>
     <command id="org.elysium.ui.commands.SyntaxUpdateSelected" name="Update Syntax" categoryId="org.elysium.ui.commandCategories.LilyPond"/>
   </extension>
   <extension point="org.eclipse.ui.handlers">
@@ -436,7 +445,16 @@
             <equals value="org.elysium.ui.perspectives.LilyPond"/>
           </with>
         </visibleWhen>
-        <command commandId="org.elysium.ui.commands.RecompileSelected"/>
+        <command commandId="org.elysium.ui.commands.RecompileSelected" label="Recompile All"/>
+        <command
+              commandId="org.elysium.ui.commands.RecompileSelected"
+              icon="icons/outdated/Marker.png"
+              label="Recompile Outdated">
+           <parameter
+                 name="org.elysium.ui.commands.RecompileSelected.outdatedOnly"
+                 value="true">
+           </parameter>
+        </command>
         <command commandId="org.elysium.ui.commands.SyntaxUpdateSelected"/>
       </menu>
     </menuContribution>

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/handlers/RecompileSelectedHandler.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/handlers/RecompileSelectedHandler.java
@@ -1,9 +1,7 @@
 package org.elysium.ui.compiler.handlers;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -49,7 +47,7 @@ public class RecompileSelectedHandler extends AbstractHandler {
 					containedFiles.add((IFile)element);
 				} else if (element instanceof IContainer) {
 					IContainer container = (IContainer)element;
-					containedFiles.addAll(getFilesToCompileFromContainer(container));
+					containedFiles.addAll(ResourceUtils.getAllFiles(container));
 				}
 				for (IFile file : containedFiles) {
 					IFile source = getLilyPondSourceFile(file);
@@ -65,14 +63,13 @@ public class RecompileSelectedHandler extends AbstractHandler {
 				files.add(source);	
 			}
 		}
-		builder.get().compile(files);
+		builder.get().compile(filterFilesToCompile(files));
 		return null;
 	}
 
-	private List<IFile> getFilesToCompileFromContainer(IContainer container){
-		List<IFile> allFiles=ResourceUtils.getAllFiles(container);
+	private Set<IFile> filterFilesToCompile(Set<IFile> allFiles){
 		if(compileOutdatedOnly) {
-			List<IFile> outdated=new ArrayList<>();
+			Set<IFile> outdated=new HashSet<>();
 			for (IFile file : allFiles) {
 				try {
 					if(file.findMarkers(MarkerTypes.OUTDATED, false, IResource.DEPTH_ZERO).length>0) {


### PR DESCRIPTION
As recompilation is not possible on an ily file anymore, it may be less easy to invoke recompilation on all including files (which may be spread over different folders), especially if compile on save is deactivated.
This pull request introduces a preference value controlling whether all files or only those marked as outdated will be processed, when recompilation is invoked on a folder or a project.

(My hope was that this makes #127 obsolete, as the Elysium's compiler preference page is completely different from the standard Xtext preference page and hence allowing project specific settings may not be easy. However, the use case there - compile on save in one project but not another - remains)