### PR TITLE
Compile dirty

### DIFF
--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondPerspective.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/LilyPondPerspective.java
@@ -1,7 +1,15 @@
 package org.elysium.ui;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.ui.IEditorReference;
 import org.eclipse.ui.IPageLayout;
 import org.eclipse.ui.IPerspectiveFactory;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.ide.ResourceUtil;
+import org.eclipse.util.EditorUtils;
 
 /**
  * Perspective for LilyPond-oriented workflows.
@@ -11,6 +19,22 @@ public class LilyPondPerspective implements IPerspectiveFactory {
 	@Override
 	public void createInitialLayout(IPageLayout layout) {
 		// See plugin.xml
+	}
+
+	public static List<IFile> getAllOpenDirtyFiles(){
+		List<IFile> result=new ArrayList<>();
+		IEditorReference[] editors = EditorUtils.getOpenEditors();
+		for (IEditorReference ref : editors) {
+			if(ref.isDirty()) {
+				try {
+					IFile file = ResourceUtil.getFile(ref.getEditorInput());
+					result.add(file);
+				} catch (PartInitException e) {
+					//ignore
+				}
+			}
+		}
+		return result;
 	}
 
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
@@ -32,11 +32,7 @@ import org.eclipse.emf.util.ResourceUtils;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IEditorReference;
-import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.ide.ResourceUtil;
-import org.eclipse.util.EditorUtils;
 import org.eclipse.xtext.builder.IXtextBuilderParticipant;
 import org.eclipse.xtext.resource.IReferenceDescription;
 import org.eclipse.xtext.resource.IResourceDescription;
@@ -44,6 +40,7 @@ import org.eclipse.xtext.resource.IResourceDescription.Delta;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 import org.elysium.LilyPondConstants;
 import org.elysium.ui.Activator;
+import org.elysium.ui.LilyPondPerspective;
 import org.elysium.ui.compiler.outdated.OutdatedDecorator;
 import org.elysium.ui.compiler.preferences.CompilerPreferenceConstants;
 
@@ -151,7 +148,7 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 
 	private boolean continueWithOpenFilesDirty(Collection<IFile> filesToCompile) {
 		AtomicBoolean doContinue=new AtomicBoolean(true);
-		List<IFile> allOpenDirtyFiles=getAllOpenDirtyFiles();
+		List<IFile> allOpenDirtyFiles=LilyPondPerspective.getAllOpenDirtyFiles();
 		if(!allOpenDirtyFiles.isEmpty()) {
 			List<String> openDirtyFilesToCompile=new ArrayList<>();
 			Set<IFile> filesInvolvedInCompilation=new HashSet<>(filesToCompile);
@@ -176,22 +173,6 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 			}
 		}
 		return doContinue.get();
-	}
-
-	private List<IFile> getAllOpenDirtyFiles(){
-		List<IFile> result=new ArrayList<>();
-		IEditorReference[] editors = EditorUtils.getOpenEditors();
-		for (IEditorReference ref : editors) {
-			if(ref.isDirty()) {
-				try {
-					IFile file = ResourceUtil.getFile(ref.getEditorInput());
-					result.add(file);
-				} catch (PartInitException e) {
-					//ignore
-				}
-			}
-		}
-		return result;
 	}
 
 	private Set<IFile> getTransitivelyIncludedFiles(Collection<IFile> files){

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
@@ -5,12 +5,14 @@ import static org.eclipse.core.resources.IResource.DEPTH_ZERO;
 import static org.elysium.ui.markers.MarkerTypes.OUTDATED;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import javax.inject.Inject;
@@ -27,7 +29,14 @@ import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.util.ResourceUtils;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.ResourceUtil;
+import org.eclipse.util.EditorUtils;
 import org.eclipse.xtext.builder.IXtextBuilderParticipant;
 import org.eclipse.xtext.resource.IReferenceDescription;
 import org.eclipse.xtext.resource.IResourceDescription;
@@ -37,6 +46,9 @@ import org.elysium.LilyPondConstants;
 import org.elysium.ui.Activator;
 import org.elysium.ui.compiler.outdated.OutdatedDecorator;
 import org.elysium.ui.compiler.preferences.CompilerPreferenceConstants;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 
 /**
  * Performs automatic incremental build on LilyPond source files.
@@ -131,8 +143,76 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 				return o1.getName().compareTo(o2.getName());
 			}
 		});
+		if(!continueWithOpenFilesDirty(sortedFiles)) {
+			return ImmutableList.of();
+		}
 		return sortedFiles;
+	}
 
+	private boolean continueWithOpenFilesDirty(Collection<IFile> filesToCompile) {
+		AtomicBoolean doContinue=new AtomicBoolean(true);
+		List<IFile> allOpenDirtyFiles=getAllOpenDirtyFiles();
+		if(!allOpenDirtyFiles.isEmpty()) {
+			List<String> openDirtyFilesToCompile=new ArrayList<>();
+			Set<IFile> filesInvolvedInCompilation=new HashSet<>(filesToCompile);
+			filesInvolvedInCompilation.addAll(getTransitivelyIncludedFiles(filesToCompile));
+			for (IFile openDirtyFile : allOpenDirtyFiles) {
+				if(filesInvolvedInCompilation.contains(openDirtyFile)) {
+					openDirtyFilesToCompile.add(openDirtyFile.getName());
+				}
+			}
+			if(!openDirtyFilesToCompile.isEmpty()) {
+				Display.getDefault().syncExec(new Runnable() {
+					@Override
+					public void run() {
+						doContinue.set(MessageDialog.openQuestion(PlatformUI.getWorkbench().getDisplay().getActiveShell(),
+								"Continue compilation ignoring unsaved changes",
+								"The compilation involves unsaved files opened in an editor:\n"+
+										Joiner.on(", ").join(openDirtyFilesToCompile)+
+								"\n\nUnsaved changes made to these files are ignored in the compailation. \nDo you want to continue?"));
+						
+					}
+				});
+			}
+		}
+		return doContinue.get();
+	}
+
+	private List<IFile> getAllOpenDirtyFiles(){
+		List<IFile> result=new ArrayList<>();
+		IEditorReference[] editors = EditorUtils.getOpenEditors();
+		for (IEditorReference ref : editors) {
+			if(ref.isDirty()) {
+				try {
+					IFile file = ResourceUtil.getFile(ref.getEditorInput());
+					result.add(file);
+				} catch (PartInitException e) {
+					//ignore
+				}
+			}
+		}
+		return result;
+	}
+
+	private Set<IFile> getTransitivelyIncludedFiles(Collection<IFile> files){
+		Set<String> fileURIs=new HashSet<>();
+		for (IFile iFile : files) {
+			fileURIs.add(iFile.getLocationURI().toString());
+			fileURIs.add(URI.createPlatformResourceURI(iFile.getFullPath().toString(), true).toString());
+		}
+		Set<String> includedURI=new HashSet<>();
+		for (IResourceDescription next : getLilyPondDescriptions()) {
+			Iterator<IReferenceDescription> lilyPonds = next.getReferenceDescriptions().iterator();
+			while(lilyPonds.hasNext()) {
+				IReferenceDescription ll = lilyPonds.next();
+				if(ll.getEReference()==null) {
+					if(fileURIs.contains(ll.getSourceEObjectUri().toString())) {
+						includedURI.add(ll.getTargetEObjectUri().toString());
+					}
+				}
+			}
+		}
+		return getFilesForUris(includedURI);
 	}
 
 	/**
@@ -148,12 +228,7 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 		}
 
 		Set<String> includingURIs=new HashSet<>();
-
-		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-
-		Iterator<IResourceDescription> indexIterator = index.getAllResourceDescriptions().iterator();
-		while(indexIterator.hasNext()) {
-			IResourceDescription next = indexIterator.next();
+		for (IResourceDescription next : getLilyPondDescriptions()) {
 			Iterator<IReferenceDescription> lilyPonds = next.getReferenceDescriptions().iterator();
 			while(lilyPonds.hasNext()) {
 				IReferenceDescription ll = lilyPonds.next();
@@ -165,19 +240,38 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 			}
 		}
 
-		for (String uriString : includingURIs) {
+		files.addAll(getFilesForUris(includingURIs));
+	}
+
+	private Set<IFile> getFilesForUris(Collection<String> uris){
+		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+		Set<IFile> result=new HashSet<>();
+		for (String uriString : uris) {
 			URI includingUri = URI.createURI(uriString);
 			if(includingUri.isPlatform()) {
 				IFile file = root.getFile(new Path(includingUri.toPlatformString(true)));
-				files.add(file);
+				result.add(file);
 			}else if(includingUri.isFile()){
 				IFile[] foundFiles = root.findFilesForLocationURI(java.net.URI.create(uriString));
 				for (IFile iFile : foundFiles) {
 					if(iFile.exists()) {
-						files.add(iFile);
+						result.add(iFile);
 					}
 				}
 			}
 		}
+		return result;
+	}
+
+	private List<IResourceDescription> getLilyPondDescriptions(){
+		List<IResourceDescription> result = new ArrayList<>();
+		Iterator<IResourceDescription> indexIterator = index.getAllResourceDescriptions().iterator();
+		while(indexIterator.hasNext()) {
+			IResourceDescription next = indexIterator.next();
+			if(LilyPondConstants.EXTENSIONS.contains(next.getURI().fileExtension())){
+				result.add(next);
+			}
+		}
+		return result;
 	}
 }

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/LilyPondBuilder.java
@@ -166,7 +166,7 @@ public class LilyPondBuilder implements IXtextBuilderParticipant {
 								"Continue compilation ignoring unsaved changes",
 								"The compilation involves unsaved files opened in an editor:\n"+
 										Joiner.on(", ").join(openDirtyFilesToCompile)+
-								"\n\nUnsaved changes made to these files are ignored in the compailation. \nDo you want to continue?"));
+								"\n\nUnsaved changes made to these files are ignored in the compilation. \nDo you want to continue?"));
 						
 					}
 				});

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoring.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondRefactoring.java
@@ -3,6 +3,7 @@ package org.elysium.ui.refactoring;
 import java.io.File;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -117,6 +118,10 @@ class LilyPondRefactoring {
 
 	public Set<URI> getRefactoredFilesPlatformURIs(){
 		return platformURItoFileOfRefactorTargets.keySet();
+	}
+
+	public Collection<IFile> getRefactoredFiles(){
+		return platformURItoFileOfRefactorTargets.values();
 	}
 
 	public Set<URI> getRefactoredFilesPlatformURIs(Set<URI> fileURIsOfIncludes){

--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondSourceFileRefactoring.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/refactoring/LilyPondSourceFileRefactoring.java
@@ -1,6 +1,7 @@
 package org.elysium.ui.refactoring;
 
 import java.text.MessageFormat;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -222,5 +223,26 @@ class LilyPondSourceFileRefactoring {
 				status.addWarning(MessageFormat.format("{0} - located in the same project as a {1}d file - has an include using variables; updating includes may fail", getUriDisplayString(), rootRefactoring.getOperation()));
 			}
 		}
+	}
+
+	/**
+	 * return refactoring targets contained in the given parameter list
+	 * */
+	public Set<IFile> getRefactoredFiles(List<IFile> filesToCheck) {
+		Collection<IFile> refactoringTargets = rootRefactoring.getRefactoredFiles();
+		Set<IFile>result = new HashSet<>();
+		for (IFile iFile : refactoringTargets) {
+			if(filesToCheck.contains(iFile)) {
+				result.add(iFile);
+			}
+		}
+		IFile me = rootRefactoring.asFile(getURI());
+		if(filesToCheck.contains(me)) {
+			if(getIncludedRefactoredFiles().size() > 0) {
+				//an include in the current file is involved, so the file's includes would have to be modified
+				result.add(me);
+			}
+		}
+		return result;
 	}
 }


### PR DESCRIPTION
This PR addresses #106. When compilation is invoked and involves open dirty files, the user is asked whether to continue (ignoring the unsaved changes). Aborting the compilation allows the user to create a clean state and then invoke compilation again.

Refactorings are completely prevented if an open dirty file is involved.