### PR TITLE
fix compilation of linked files

### DIFF
--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerProcessBuilderFactory.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/compiler/CompilerProcessBuilderFactory.java
@@ -85,7 +85,7 @@ public class CompilerProcessBuilderFactory {
 	}
 
 	public static void prepareProcessBuilder(ProcessBuilder processBuilder, IFile file) {
-		File directory = file.getParent().getLocation().toFile();
+		File directory = file.getLocation().removeLastSegments(1).toFile();
 		processBuilder.directory(directory);
 
 		List<String> command = processBuilder.command();


### PR DESCRIPTION
If a compile action is invoked on a linked file, currently the compiler cannot find it. This is because the IFile's parent (actual workspace project) may not be the phyiscal parent of the file. Changing the order - getting the location (path) and then removing the last segment - fixes this problem.

However, the linked file support is not perfect, even then. Show in score/audio might well fail because the compiled files are not automatically linked. Replacing the file extension of the source file leads to an IFile which is unknown to Eclipse.

I guess, linked files are hardly used, so even the bug fix of this PR could be ignored...