### PR TITLE
#25 fix multi line comment auto edit

### DIFF
--- a/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/autoedit/LilyPondAutoEditStrategyProvider.java
+++ b/org.elysium.parent/org.elysium.ui/src/org/elysium/ui/autoedit/LilyPondAutoEditStrategyProvider.java
@@ -11,25 +11,30 @@ import org.elysium.formatting2.LilyPondFormatter;
  */
 public class LilyPondAutoEditStrategyProvider extends DefaultAutoEditStrategyProvider {
 
-	private static void accept(IEditStrategyAcceptor acceptor, IAutoEditStrategy strategy) {
+	private static void accept(IEditStrategyAcceptor acceptor, IAutoEditStrategy strategy, String left) {
 		acceptor.accept(strategy, IDocument.DEFAULT_CONTENT_TYPE);
-		acceptor.accept(strategy, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
+		if(!"{".equals(left)) {//$NON-NLS-1$
+			acceptor.accept(strategy, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
+		}
+		if("%{".equals(left)) {//$NON-NLS-1$
+			acceptor.accept(strategy, TerminalsTokenTypeToPartitionMapper.SL_COMMENT_PARTITION);
+		}
 	}
 
 	@Override
 	protected void configure(IEditStrategyAcceptor acceptor) {
-		accept(acceptor, defaultIndentLineAutoEditStrategy.get());
+		accept(acceptor, defaultIndentLineAutoEditStrategy.get(), null);
 		for (String[] blockKeywordPair : LilyPondFormatter.BLOCK_KEYWORD_PAIRS) {
-			accept(acceptor, singleLineTerminals.newInstance(blockKeywordPair[0], blockKeywordPair[1]));
-			accept(acceptor, multiLineTerminals.newInstance(blockKeywordPair[0], null, blockKeywordPair[1]));
+			String left=blockKeywordPair[0];
+			accept(acceptor, singleLineTerminals.newInstance(left, blockKeywordPair[1]), left);
+			accept(acceptor, multiLineTerminals.newInstance(left, null, blockKeywordPair[1]), left);
 		}
 		final String[][] brackets = new String[][] { { "[", "]" }, //$NON-NLS-1$ //$NON-NLS-2$
 			{ "\\(", "\\)" }, //$NON-NLS-1$ //$NON-NLS-2$
 			{ "(", ")" } }; //$NON-NLS-1$ //$NON-NLS-2$
 		for (String[] blockKeywordPair : brackets) {
-			accept(acceptor, singleLineTerminals.newInstance(blockKeywordPair[0], blockKeywordPair[1]));
+			accept(acceptor, singleLineTerminals.newInstance(blockKeywordPair[0], blockKeywordPair[1]), null);
 		}
-		accept(acceptor, partitionInsert.newInstance("\"", "\"")); //$NON-NLS-1$ //$NON-NLS-2$
+		accept(acceptor, partitionInsert.newInstance("\"", "\""), null); //$NON-NLS-1$ //$NON-NLS-2$
 	}
-
 }


### PR DESCRIPTION
This PR addresses #25. Auto edit for multi line comments failed because the strategy was not registered for the single line comment partition, but if the prefix is `%` this will be the current partition.

This current fix also involves *not* registering regular braces `{}` for the comment partition. This is because braces and multiline comment strategy will fire simultaneously leading to strange results when pressing enter between `%{` and `%}`. This is the simplest solution. Of course auto edit for braces will now not work when in a comment or multi line comment, which I consider acceptable.
Otherwise we would have to sub class the strategy and apply it for braces only if there was no percent befor the brace.